### PR TITLE
update translations; small HHD changes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -258,8 +258,6 @@ only_rules:
   - redundant_nil_coalescing
   # Objective-C attribute (@objc) is redundant in declaration.
   - redundant_objc_attribute
-  # Initializing an optional variable with nil is redundant.
-  - redundant_optional_initialization
   # Property setter access level shouldn't be explicit if it's the same as the variable access level.
   - redundant_set_access_control
   # String enum values can be omitted when they are equal to the enumcase name.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,5 +12,5 @@ My Heart Counts Contributors
 =================================
 
 - [Lukas Kollmer](https://github.com/lukaskollmer)
-- [Paul Goldschmidt](https://github.com/https://github.com/PaulGoldschmidt)
+- [Paul Goldschmidt](https://github.com/PaulGoldschmidt)
 - [Paul Schmiedmayer](https://github.com/PSchmiedmayer)

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1768,8 +1768,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFoundation.git";
 			requirement = {
-				kind = revision;
-				revision = bf05098ed12ff89972388017975bb9cd12ebb340;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.1;
 			};
 		};
 		8043E0092DC2348600E0DF01 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
@@ -1888,8 +1888,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
 			requirement = {
-				kind = revision;
-				revision = c9e719c9dcfeba885b4214afebe8acc7106b7c42;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.4;
 			};
 		};
 		A94DDFFB2CBD1190004930BD /* XCRemoteSwiftPackageReference "SpeziNotifications" */ = {

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1822,7 +1822,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziSensorKit.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.1.1;
+				minimumVersion = 0.1.2;
 			};
 		};
 		808A92C92E47E159007046E0 /* XCRemoteSwiftPackageReference "SpeziConsent" */ = {
@@ -1885,8 +1885,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.3;
+				kind = revision;
+				revision = 54426680cc9ede334674b8f1d41c787539344207;
 			};
 		};
 		A94DDFFB2CBD1190004930BD /* XCRemoteSwiftPackageReference "SpeziNotifications" */ = {

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1670,7 +1670,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/Spezi.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.9.1;
+				minimumVersion = 1.9.2;
 			};
 		};
 		2F66D20D2BB723180010D555 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
@@ -1886,7 +1886,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
 			requirement = {
 				kind = revision;
-				revision = 54426680cc9ede334674b8f1d41c787539344207;
+				revision = c9e719c9dcfeba885b4214afebe8acc7106b7c42;
 			};
 		};
 		A94DDFFB2CBD1190004930BD /* XCRemoteSwiftPackageReference "SpeziNotifications" */ = {

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		8004CE412D75BCAA00CC3008 /* SpeziOnboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 8004CE402D75BCAA00CC3008 /* SpeziOnboarding */; };
 		8004CE442D75BCBE00CC3008 /* SpeziStudy in Frameworks */ = {isa = PBXBuildFile; productRef = 8004CE432D75BCBE00CC3008 /* SpeziStudy */; };
 		800BA3432E40DB4D00A90912 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 800BA3422E40DB4D00A90912 /* FirebaseFunctions */; };
+		800C3A1A2E6A2E5200759CDD /* SpeziFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 800C3A192E6A2E5200759CDD /* SpeziFoundation */; };
+		800C3A1C2E6A2E5200759CDD /* SpeziLocalization in Frameworks */ = {isa = PBXBuildFile; productRef = 800C3A1B2E6A2E5200759CDD /* SpeziLocalization */; };
 		8020A0462E3CFF6F005EF814 /* SpeziHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8020A0452E3CFF6F005EF814 /* SpeziHealthKit */; };
 		802141592D81F14000BF5D35 /* SpeziOnboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 802141582D81F14000BF5D35 /* SpeziOnboarding */; };
 		80270CFB2D67F68F0022251E /* SpeziStudy in Frameworks */ = {isa = PBXBuildFile; productRef = 80270CFA2D67F68F0022251E /* SpeziStudy */; };
@@ -81,7 +83,6 @@
 		80A008462DEFD0F900A446BA /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 80A008452DEFD0F900A446BA /* OrderedCollections */; };
 		80A81C692D7C89D400444A17 /* SpeziStudy in Frameworks */ = {isa = PBXBuildFile; productRef = 80A81C682D7C89D400444A17 /* SpeziStudy */; };
 		80BE06542DCF3A6D00171114 /* SwiftPackageList in Frameworks */ = {isa = PBXBuildFile; productRef = 80BE06532DCF3A6D00171114 /* SwiftPackageList */; };
-		80C6AFF22E33E4D200D22DCB /* SpeziFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 80C6AFF12E33E4D200D22DCB /* SpeziFoundation */; };
 		80C7B86C2D67D76B0016BCAF /* SpeziOnboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 80C7B86B2D67D76B0016BCAF /* SpeziOnboarding */; };
 		80D0E7062E3A3728000227E9 /* SpeziLocalization in Frameworks */ = {isa = PBXBuildFile; productRef = 80D0E7052E3A3728000227E9 /* SpeziLocalization */; };
 		80D0E7082E3A3728000227E9 /* SpeziStudy in Frameworks */ = {isa = PBXBuildFile; productRef = 80D0E7072E3A3728000227E9 /* SpeziStudy */; };
@@ -239,6 +240,7 @@
 				803166A32D75DE6100E9173B /* SpeziOnboarding in Frameworks */,
 				8043E00B2DC2348600E0DF01 /* MarkdownUI in Frameworks */,
 				8004CE412D75BCAA00CC3008 /* SpeziOnboarding in Frameworks */,
+				800C3A1A2E6A2E5200759CDD /* SpeziFoundation in Frameworks */,
 				805C02F82D832EFB005B38D9 /* SpeziFirebaseStorage in Frameworks */,
 				80E08A742DD32D9F00E80C11 /* SpeziHealthKitBulkExport in Frameworks */,
 				808E10052DAD48F300DB240D /* SpeziHealthKit in Frameworks */,
@@ -247,7 +249,6 @@
 				2FB099AF2A875DF100B20952 /* FirebaseAuth in Frameworks */,
 				80D41BE92E25A9BC00D5EAAB /* ResearchKitOnFHIR in Frameworks */,
 				803D2B442D8981EA00DAEF9B /* SpeziStudyDefinition in Frameworks */,
-				80C6AFF22E33E4D200D22DCB /* SpeziFoundation in Frameworks */,
 				80F8A3AB2E20496E00C6322F /* SpeziHealthKitUI in Frameworks */,
 				807669732D772C40001B980B /* Collections in Frameworks */,
 				2FE5DC6729EDD894004B9AB4 /* SpeziContact in Frameworks */,
@@ -290,6 +291,7 @@
 				80E08A762DD32D9F00E80C11 /* SpeziHealthKitUI in Frameworks */,
 				2FE5DC8A29EDD972004B9AB4 /* SpeziLocalStorage in Frameworks */,
 				807669752D772C40001B980B /* DequeModule in Frameworks */,
+				800C3A1C2E6A2E5200759CDD /* SpeziLocalization in Frameworks */,
 				80D0E7062E3A3728000227E9 /* SpeziLocalization in Frameworks */,
 				80D612F02D67A5D200FAE750 /* SpeziKeychainStorage in Frameworks */,
 				9739A0C62AD7B5730084BEA5 /* FirebaseStorage in Frameworks */,
@@ -516,7 +518,6 @@
 				80F8A3A82E20496E00C6322F /* SpeziHealthKitBulkExport */,
 				80F8A3AA2E20496E00C6322F /* SpeziHealthKitUI */,
 				80D41BE82E25A9BC00D5EAAB /* ResearchKitOnFHIR */,
-				80C6AFF12E33E4D200D22DCB /* SpeziFoundation */,
 				8004BDFC2E34F8A2002B27F2 /* XCTSpeziNotificationsUI */,
 				80D0E7052E3A3728000227E9 /* SpeziLocalization */,
 				80D0E7072E3A3728000227E9 /* SpeziStudy */,
@@ -526,6 +527,8 @@
 				800BA3422E40DB4D00A90912 /* FirebaseFunctions */,
 				808A927C2E47900B007046E0 /* SpeziSensorKit */,
 				808A92CA2E47E159007046E0 /* SpeziConsent */,
+				800C3A192E6A2E5200759CDD /* SpeziFoundation */,
+				800C3A1B2E6A2E5200759CDD /* SpeziLocalization */,
 			);
 			productName = MyHeartCounts;
 			productReference = 653A254D283387FE005D4D48 /* MyHeartCounts.app */;
@@ -701,11 +704,11 @@
 				80A3A4812E1EB270002A8515 /* XCRemoteSwiftPackageReference "ResearchKit" */,
 				80F8A3A52E20496E00C6322F /* XCRemoteSwiftPackageReference "SpeziHealthKit" */,
 				80D41BE72E25A9BC00D5EAAB /* XCRemoteSwiftPackageReference "ResearchKitOnFHIR" */,
-				80C6AFF02E33E4D200D22DCB /* XCRemoteSwiftPackageReference "SpeziFoundation" */,
 				80D0E7042E3A3728000227E9 /* XCRemoteSwiftPackageReference "SpeziStudy" */,
 				8087AE372E3A658100601154 /* XCRemoteSwiftPackageReference "SpeziScheduler" */,
 				808A927B2E47900B007046E0 /* XCRemoteSwiftPackageReference "SpeziSensorKit" */,
 				808A92C92E47E159007046E0 /* XCRemoteSwiftPackageReference "SpeziConsent" */,
+				800C3A182E6A2E5200759CDD /* XCRemoteSwiftPackageReference "SpeziFoundation" */,
 			);
 			productRefGroup = 653A254E283387FE005D4D48 /* Products */;
 			projectDirPath = "";
@@ -1726,7 +1729,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziViews.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.12.1;
+				minimumVersion = 1.12.2;
 			};
 		};
 		2FE5DC9029EDD9C3004B9AB4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
@@ -1759,6 +1762,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.0.0;
+			};
+		};
+		800C3A182E6A2E5200759CDD /* XCRemoteSwiftPackageReference "SpeziFoundation" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziFoundation.git";
+			requirement = {
+				kind = revision;
+				revision = bf05098ed12ff89972388017975bb9cd12ebb340;
 			};
 		};
 		8043E0092DC2348600E0DF01 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
@@ -1849,20 +1860,12 @@
 				minimumVersion = 4.8.0;
 			};
 		};
-		80C6AFF02E33E4D200D22DCB /* XCRemoteSwiftPackageReference "SpeziFoundation" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/SpeziFoundation.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.2.1;
-			};
-		};
 		80D0E7042E3A3728000227E9 /* XCRemoteSwiftPackageReference "SpeziStudy" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziStudy.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.9;
+				minimumVersion = 0.1.10;
 			};
 		};
 		80D41BE72E25A9BC00D5EAAB /* XCRemoteSwiftPackageReference "ResearchKitOnFHIR" */ = {
@@ -1981,6 +1984,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2FE5DC9029EDD9C3004B9AB4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseFunctions;
+		};
+		800C3A192E6A2E5200759CDD /* SpeziFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 800C3A182E6A2E5200759CDD /* XCRemoteSwiftPackageReference "SpeziFoundation" */;
+			productName = SpeziFoundation;
+		};
+		800C3A1B2E6A2E5200759CDD /* SpeziLocalization */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 800C3A182E6A2E5200759CDD /* XCRemoteSwiftPackageReference "SpeziFoundation" */;
+			productName = SpeziLocalization;
 		};
 		8020A0452E3CFF6F005EF814 /* SpeziHealthKit */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -2245,11 +2258,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 80BE064E2DCF3A2D00171114 /* XCRemoteSwiftPackageReference "swift-package-list" */;
 			productName = SwiftPackageList;
-		};
-		80C6AFF12E33E4D200D22DCB /* SpeziFoundation */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 80C6AFF02E33E4D200D22DCB /* XCRemoteSwiftPackageReference "SpeziFoundation" */;
-			productName = SpeziFoundation;
 		};
 		80C7B86B2D67D76B0016BCAF /* SpeziOnboarding */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi.git",
       "state" : {
-        "revision" : "6bed41a437cba200a8ce0182e6a30dc787bbc836",
-        "version" : "1.9.1"
+        "revision" : "aea262c1bba638494c3ce9a749e834aafd10ba63",
+        "version" : "1.9.2"
       }
     },
     {
@@ -276,7 +276,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
       "state" : {
-        "revision" : "54426680cc9ede334674b8f1d41c787539344207"
+        "revision" : "c9e719c9dcfeba885b4214afebe8acc7106b7c42"
       }
     },
     {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7ff5a9f0ade1c99877e8fd99777bc8b88464d8c7523138373b972929f368d078",
+  "originHash" : "3f04a957fe73cd5a207b257e8b3dab8214337e230955f9ae99ebde7a4e9f166c",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -267,7 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFoundation.git",
       "state" : {
-        "revision" : "bf05098ed12ff89972388017975bb9cd12ebb340"
+        "revision" : "eaf89f70c255f21cafabdca5c731fa15f618432b",
+        "version" : "2.4.1"
       }
     },
     {
@@ -275,7 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
       "state" : {
-        "revision" : "c9e719c9dcfeba885b4214afebe8acc7106b7c42"
+        "revision" : "368ac5a67bb03f1c5c24bc554868a38b527416b9",
+        "version" : "1.2.4"
       }
     },
     {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3f04a957fe73cd5a207b257e8b3dab8214337e230955f9ae99ebde7a4e9f166c",
+  "originHash" : "7ff5a9f0ade1c99877e8fd99777bc8b88464d8c7523138373b972929f368d078",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -267,8 +267,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFoundation.git",
       "state" : {
-        "revision" : "89f3334e685ddad1bbf2e8b33fa0820620aec6c1",
-        "version" : "2.2.1"
+        "revision" : "bf05098ed12ff89972388017975bb9cd12ebb340"
       }
     },
     {
@@ -347,8 +346,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziStudy.git",
       "state" : {
-        "revision" : "de1e38f04c52813bdc7d0949628b5f712bb7d43b",
-        "version" : "0.1.9"
+        "revision" : "15ae5191fe6104806ca5e390965b23ebb93822e4",
+        "version" : "0.1.10"
       }
     },
     {
@@ -356,8 +355,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziViews.git",
       "state" : {
-        "revision" : "9a7cd323ae6023a57bdf57af644538e723902f67",
-        "version" : "1.12.1"
+        "revision" : "8c12a94fcd118128db87736b849e71dbca7d1a46",
+        "version" : "1.12.2"
       }
     },
     {
@@ -527,8 +526,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git",
       "state" : {
-        "revision" : "d3394b8c432f4e3d30cdf14cb5892695e923b06d",
-        "version" : "2.1.0"
+        "revision" : "ba5753f59905b80fd98d0da0f552f4e5d5c0488e",
+        "version" : "2.2.0"
       }
     },
     {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -276,8 +276,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
       "state" : {
-        "revision" : "4fab93e2ba8b62ddc45f50a61043d7df376243ba",
-        "version" : "1.2.3"
+        "revision" : "54426680cc9ede334674b8f1d41c787539344207"
       }
     },
     {
@@ -330,8 +329,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziSensorKit.git",
       "state" : {
-        "revision" : "565c276b46ad24c1644d1fe4b2e7fe5f37e2d112",
-        "version" : "0.1.1"
+        "revision" : "a80ecba0b4c0a966f5d176e2be73b27278f7b7e0",
+        "version" : "0.1.2"
       }
     },
     {

--- a/MyHeartCounts/Active Tasks/TimedWalkingTestView.swift
+++ b/MyHeartCounts/Active Tasks/TimedWalkingTestView.swift
@@ -65,11 +65,22 @@ struct TimedWalkingTestView: View { // swiftlint:disable:this file_types_order
     }
     
     @ViewBuilder private var sections: some View {
+        let durationInMinutes = (test.duration.totalSeconds / 60).formatted(.number.precision(.fractionLength(0...1)))
         PlainSection {
             CenterH {
-                Text("Timed Walking Test")
-                    .font(.title.bold())
+                switch test.kind {
+                case .walking:
+                    Text("\(durationInMinutes)-Minute Walk Test")
+                case .running:
+                    if test == .twelveMinuteRunTest {
+                        Text("12-Minute Run Test (Cooper Test)")
+                    } else {
+                        Text("\(durationInMinutes)-Minute Run Test")
+                    }
+                }
             }
+            .font(.title.bold())
+            .multilineTextAlignment(.center)
         }
         PlainSection {
             CenterH {
@@ -84,17 +95,25 @@ struct TimedWalkingTestView: View { // swiftlint:disable:this file_types_order
             }
         }
         PlainSection {
-            let durationInMinutes = (test.duration.totalSeconds / 60).formatted(.number.precision(.fractionLength(0...1)))
-            let kindText = switch test.kind {
-            case .walking: "walking"
-            case .running: "running"
+            let kindText: LocalizedStringResource = switch test.kind {
+            case .walking: "walk"
+            case .running: "run"
             }
-            Text("As part of the \(test.displayTitle), we'll collect some mobility information from your iPhone and Apple Watch, such as Step Count, Distance, and Heart Rate, while you go on a short walk for \(durationInMinutes) minute\(test.duration == .minutes(1) ? "" : "s")")
+            switch test {
+            case .sixMinuteWalkTest:
+                Text("TIMED_WALK_TEST_EXPLAINER_6_MIN_WALK")
+            case .twelveMinuteRunTest:
+                Text("TIMED_WALK_TEST_EXPLAINER_12_MIN_RUN")
+            default:
+                // ???
+                Text("TIMED_WALK_TEST_EXPLAINER_6_MIN_WALK")
+            }
             if watchParticipatesInTest {
                 Text("For optimal results, please keep your Phone in your pocket, and \(kindText) until your Watch vibrates to indicate that the test has ended.")
             } else {
                 Text("For optimal results, please keep your Phone in your pocket, and \(kindText) until it vibrates to indicate that the test has ended.")
             }
+            Text("TIMED_WALK_TEST_EXPLAINER_FOOTER")
         }
         if !testIsRunning {
             if watchManager.userHasWatch && !watchManager.isWatchAppReachable {

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/DefaultHealthDashboardComponentGridCell.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/DefaultHealthDashboardComponentGridCell.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-// swiftlint:disable file_types_order
+// swiftlint:disable file_types_order all
 
 import Charts
 import Foundation
@@ -14,6 +14,7 @@ import HealthKit
 import SpeziFoundation
 import SpeziHealthKit
 import SpeziHealthKitUI
+import SpeziViews
 import SwiftUI
 
 
@@ -462,7 +463,6 @@ extension SamplesProviderView {
     private struct FirestoreImpl: View {
         @MHCFirestoreQuery<QuantitySample> var samples: [QuantitySample]
         let content: @MainActor ([QuantitySample]) -> Content
-        
         
         var body: some View {
             content(samples)

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboard+SleepAnalysis.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboard+SleepAnalysis.swift
@@ -171,29 +171,6 @@ struct LargeSleepAnalysisView: View {
 }
 
 
-extension Range where Bound == Date {
-    func displayText(using cal: Calendar) -> String {
-        // would it maybe make sense to have a "TimeRangeLabel"?
-        // certainly space for improvement here...
-        if self == cal.rangeOfDay(for: .now) {
-            return "Today"
-        } else if self == cal.rangeOfDay(for: self.lowerBound) {
-            return self.lowerBound.formatted(date: .abbreviated, time: .omitted)
-        } else if self.isEmpty, case let date = self.lowerBound { // startDate == endDate
-            return if cal.isDateInToday(date) && date <= .now {
-                date.formatted(date: .omitted, time: .shortened)
-            } else {
-                // is older than today
-                date.formatted(date: .numeric, time: .shortened)
-            }
-        } else {
-            let fmt = { ($0 as Date).formatted(date: .abbreviated, time: .omitted) }
-            return "\(fmt(self.lowerBound)) – \(fmt(self.upperBound.addingTimeInterval(-1)))"
-        }
-    }
-}
-
-
 extension HKObject {
     var timeZone: TimeZone? {
         if let name = metadata?[HKMetadataKeyTimeZone] as? String {

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardGridCell.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardGridCell.swift
@@ -21,8 +21,8 @@ extension HealthDashboardConstants {
 struct HealthDashboardSmallGridCell<Accessory: View, Content: View>: View {
     private static var insets: EdgeInsets { EdgeInsets(horizontal: 9, vertical: 5) }
     
-    private let title: String
-    private let subtitle: String?
+    private let title: Text
+    private let subtitle: Text?
     private let accessory: @MainActor () -> Accessory
     private let content: @MainActor () -> Content
     
@@ -31,10 +31,10 @@ struct HealthDashboardSmallGridCell<Accessory: View, Content: View>: View {
             VStack(spacing: 0) {
                 HStack {
                     VStack(alignment: .leading) {
-                        Text(title)
+                        title
                             .font(.headline)
                         if let subtitle {
-                            Text(subtitle)
+                            subtitle
                                 .font(.subheadline)
                         }
                     }
@@ -54,15 +54,27 @@ struct HealthDashboardSmallGridCell<Accessory: View, Content: View>: View {
         .background(.background)
     }
     
-    
     init(
-        title: String,
-        subtitle: String? = nil,
+        title: LocalizedStringResource,
+        subtitle: LocalizedStringResource? = nil,
         @ViewBuilder accessory: @MainActor @escaping () -> Accessory = { EmptyView() },
         @ViewBuilder content: @MainActor @escaping () -> Content
     ) {
-        self.title = title
-        self.subtitle = subtitle
+        self.title = Text(title)
+        self.subtitle = subtitle.map(Text.init)
+        self.accessory = accessory
+        self.content = content
+    }
+    
+    @_disfavoredOverload
+    init(
+        title: some StringProtocol,
+        subtitle: (some StringProtocol)? = String?.none,
+        @ViewBuilder accessory: @MainActor @escaping () -> Accessory = { EmptyView() },
+        @ViewBuilder content: @MainActor @escaping () -> Content
+    ) {
+        self.title = Text(title)
+        self.subtitle = subtitle.map(Text.init)
         self.accessory = accessory
         self.content = content
     }
@@ -90,8 +102,13 @@ struct HealthDashboardQuantityLabel: View {
             // if we have a single-value grid cell that displays the max heart rate measured today, we'd have the label at the bottom say
             // "Today", even though displaying the precise time of this max heart rate measurement would be more correct.
             Text(input.timeRange.displayText(using: cal))
-                .foregroundStyle(.secondary)
+//                .foregroundStyle(.secondary)
+                .foregroundStyle(.red)
                 .font(.footnote)
+            Text(input.timeRange.lowerBound, format: .iso8601)
+                .font(.system(size: 7).monospaced())
+            Text(input.timeRange.upperBound, format: .iso8601)
+                .font(.system(size: 7).monospaced())
         }
     }
 }

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardGridCell.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardGridCell.swift
@@ -102,13 +102,8 @@ struct HealthDashboardQuantityLabel: View {
             // if we have a single-value grid cell that displays the max heart rate measured today, we'd have the label at the bottom say
             // "Today", even though displaying the precise time of this max heart rate measurement would be more correct.
             Text(input.timeRange.displayText(using: cal))
-//                .foregroundStyle(.secondary)
-                .foregroundStyle(.red)
+                .foregroundStyle(.secondary)
                 .font(.footnote)
-            Text(input.timeRange.lowerBound, format: .iso8601)
-                .font(.system(size: 7).monospaced())
-            Text(input.timeRange.upperBound, format: .iso8601)
-                .font(.system(size: 7).monospaced())
         }
     }
 }

--- a/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
+++ b/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
@@ -31,8 +31,11 @@ struct HeartHealthDashboard: View {
         var id: ObjectIdentifier { .init(keyPath) }
     }
     
-    @Environment(\.colorScheme)
-    private var colorScheme
+    // swiftlint:disable attributes
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.calendar) private var cal
+    @Environment(StudyManager.self) private var studyManager
+    // swiftlint:enable attributes
     
     @CVHScore private var cvhScore
     
@@ -127,10 +130,11 @@ struct HeartHealthDashboard: View {
         }
     }
     
-    private var learnMoreSection: some View {
-        Section("Learn More") {
-            let text = String(localized: "HEART_HEALTH_DASHBOARD_LEARN_MORE_TEXT")
-            MarkdownView(markdownDocument: .init(metadata: [:], blocks: [.markdown(id: nil, rawContents: text)]))
+    @ViewBuilder private var learnMoreSection: some View {
+        if let learnMoreText = studyManager.localizedMarkdown(for: "LearnMore", in: .hhdExplainer) {
+            Section("Learn More") {
+                MarkdownView(markdownDocument: .init(metadata: [:], blocks: [.markdown(id: nil, rawContents: learnMoreText)]))
+            }
         }
     }
     

--- a/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
+++ b/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
@@ -167,19 +167,10 @@ struct HeartHealthDashboard: View {
                             .font(.caption2)
                     }
                     .frame(width: 50, height: 50)
-//                    if let date = score.timeRange?.upperBound {
-//                        Text(date, format: .dateTime)
-//                            .font(.footnote)
-//                            .foregroundStyle(.secondary)
-//                    }
                     if let timeRange = score.timeRange {
                         Text(timeRange.displayText(using: cal))
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                        Text(timeRange.lowerBound, format: .iso8601)
-                            .font(.system(size: 7).monospaced())
-                        Text(timeRange.upperBound, format: .iso8601)
-                            .font(.system(size: 7).monospaced())
                     }
                 }
             } else {

--- a/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
+++ b/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
@@ -167,10 +167,19 @@ struct HeartHealthDashboard: View {
                             .font(.caption2)
                     }
                     .frame(width: 50, height: 50)
-                    if let date = score.timeRange?.upperBound {
-                        Text(date, format: .dateTime)
+//                    if let date = score.timeRange?.upperBound {
+//                        Text(date, format: .dateTime)
+//                            .font(.footnote)
+//                            .foregroundStyle(.secondary)
+//                    }
+                    if let timeRange = score.timeRange {
+                        Text(timeRange.displayText(using: cal))
                             .font(.footnote)
                             .foregroundStyle(.secondary)
+                        Text(timeRange.lowerBound, format: .iso8601)
+                            .font(.system(size: 7).monospaced())
+                        Text(timeRange.upperBound, format: .iso8601)
+                            .font(.system(size: 7).monospaced())
                     }
                 }
             } else {

--- a/MyHeartCounts/Home Tab/ECGInstructions.swift
+++ b/MyHeartCounts/Home Tab/ECGInstructions.swift
@@ -1,0 +1,32 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import MarkdownUI
+import SpeziViews
+import SwiftUI
+
+
+struct ECGInstructionsSheet: View {
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading) {
+                    let text = String(localized: "ECG_INSTRUCTIONS_TEXT")
+                    Markdown(text)
+                        .padding(.horizontal)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    DismissButton()
+                }
+            }
+        }
+    }
+}

--- a/MyHeartCounts/Home Tab/HomeTab.swift
+++ b/MyHeartCounts/Home Tab/HomeTab.swift
@@ -64,6 +64,9 @@ struct HomeTab: RootViewTab {
                 }
             }
         }
+        .sheet(isPresented: .constant(true)) {
+            ECGInstructionsSheet()
+        }
     }
     
     @ViewBuilder private var topActionsFormContent: some View {

--- a/MyHeartCounts/Home Tab/HomeTab.swift
+++ b/MyHeartCounts/Home Tab/HomeTab.swift
@@ -64,9 +64,6 @@ struct HomeTab: RootViewTab {
                 }
             }
         }
-        .sheet(isPresented: .constant(true)) {
-            ECGInstructionsSheet()
-        }
     }
     
     @ViewBuilder private var topActionsFormContent: some View {

--- a/MyHeartCounts/Modules/ConsentManager.swift
+++ b/MyHeartCounts/Modules/ConsentManager.swift
@@ -9,7 +9,6 @@
 import FirebaseStorage
 import Foundation
 import Spezi
-import SpeziLocalization
 import SpeziAccount
 import SpeziFoundation
 import SpeziStudy

--- a/MyHeartCounts/Modules/ConsentManager.swift
+++ b/MyHeartCounts/Modules/ConsentManager.swift
@@ -9,6 +9,7 @@
 import FirebaseStorage
 import Foundation
 import Spezi
+import SpeziLocalization
 import SpeziAccount
 import SpeziFoundation
 import SpeziStudy

--- a/MyHeartCounts/Modules/NewsManager.swift
+++ b/MyHeartCounts/Modules/NewsManager.swift
@@ -82,7 +82,6 @@ final class NewsManager: Module, EnvironmentAccessible {
                     }
                     return storageRefs.first(where: { $0.name == result.url.lastPathComponent })
                 }
-            print("# NEWS ARTICLES: \(newsArticleStorageRefs.count)")
             var articles = await withTaskGroup(of: Article?.self, returning: [Article].self) { taskGroup in
                 for storageRef in newsArticleStorageRefs {
                     taskGroup.addTask {

--- a/MyHeartCounts/Modules/NewsManager.swift
+++ b/MyHeartCounts/Modules/NewsManager.swift
@@ -43,6 +43,9 @@ final class NewsManager: Module, EnvironmentAccessible {
         }
         let logger = logger
         let refreshTask = Task { // swiftlint:disable:this closure_body_length
+            defer {
+                self.refreshTask = nil
+            }
             let startTS = CACurrentMediaTime()
             defer {
                 let endTS = CACurrentMediaTime()
@@ -55,22 +58,31 @@ final class NewsManager: Module, EnvironmentAccessible {
                 return
             }
             logger.trace("TIME SPENT FETCHING FILEREFS: \(CACurrentMediaTime() - startTS)")
+            for fileRef in newsArticleFiles.items {
+                self.logger.notice("- \(fileRef.fullPath)")
+            }
             let newsArticleStorageRefs = newsArticleFiles.items
                 .reduce(into: [String: [StorageReference]]()) { mapping, storageRef in
-                    let url = URL(filePath: storageRef.fullPath)
-                    guard let filename = Localization.parseLocalizedFileResource(from: url)?.unlocalizedFilename else {
-                        self.logger.notice("Skipping news articles files \(storageRef) bc we were unable to extract the filename.")
+                    let url = URL(filePath: storageRef.fullPath).absoluteURL
+                    guard let fileInfo = LocalizedFileResolution.parse(url) else {
+                        self.logger.notice("Skipping news articles file \(storageRef) bc we were unable to extract the filename.")
                         return
                     }
-                    mapping[filename, default: []].append(storageRef)
+                    mapping[fileInfo.unlocalizedUrl.lastPathComponent, default: []].append(storageRef)
                 }
                 .compactMap { filename, storageRefs -> StorageReference? in
-                    let urls = storageRefs.map { URL(filePath: $0.fullPath) }
-                    guard let result = Localization.resolveFile(named: filename, from: urls, locale: locale) else {
+                    let urls = storageRefs.map { URL(filePath: $0.fullPath).absoluteURL }
+                    guard let result = LocalizedFileResolution.resolve(
+                        LocalizedFileResource(filename, locale: locale),
+                        from: urls,
+                        using: .preferLanguageMatch,
+                        fallback: .enUS
+                    ) else {
                         return nil
                     }
                     return storageRefs.first(where: { $0.name == result.url.lastPathComponent })
                 }
+            print("# NEWS ARTICLES: \(newsArticleStorageRefs.count)")
             var articles = await withTaskGroup(of: Article?.self, returning: [Article].self) { taskGroup in
                 for storageRef in newsArticleStorageRefs {
                     taskGroup.addTask {

--- a/MyHeartCounts/MyHeartCountsStandard.swift
+++ b/MyHeartCounts/MyHeartCountsStandard.swift
@@ -25,7 +25,7 @@ actor MyHeartCountsStandard: Standard, EnvironmentAccessible, AccountNotifyConst
     // swiftlint:disable attributes
     @Application(\.logger) var logger
     @Dependency(FirebaseConfiguration.self) var firebaseConfiguration
-    @Dependency(StudyManager.self) private var studyManager//: StudyManager?
+    @Dependency(StudyManager.self) private var studyManager
     @Dependency(Account.self) var account: Account?
     @Dependency(StudyBundleLoader.self) private var studyLoader
     @Dependency(TimeZoneTracking.self) private var timeZoneTracking: TimeZoneTracking?

--- a/MyHeartCounts/MyHeartCountsStandard.swift
+++ b/MyHeartCounts/MyHeartCountsStandard.swift
@@ -42,10 +42,6 @@ actor MyHeartCountsStandard: Standard, EnvironmentAccessible, AccountNotifyConst
             guard let studyManager = await self.studyManager else {
                 return
             }
-            await logger.notice("STUDIES:")
-            for enrollment in studyManager.studyEnrollments {
-                await logger.notice("- \(enrollment.studyBundle?.studyDefinition.metadata.title ?? "uhhh")")
-            }
             if let studyBundle = try? await studyLoader.update() {
                 await logger.notice("Informing StudyManager about v\(studyBundle.studyDefinition.studyRevision) of MHC studyBundle")
                 try await studyManager.informAboutStudies([studyBundle])

--- a/MyHeartCounts/MyHeartCountsStandard.swift
+++ b/MyHeartCounts/MyHeartCountsStandard.swift
@@ -83,6 +83,7 @@ actor MyHeartCountsStandard: Standard, EnvironmentAccessible, AccountNotifyConst
             try? FileManager.default.removeItem(at: .scheduledLiveHealthKitUploads)
             try? FileManager.default.removeItem(at: .scheduledHistoricalHealthKitUploads)
             try? await firebaseConfiguration.userDocumentReference.delete()
+            let studyManager = studyManager
             await MainActor.run {
                 guard let enrollment = studyManager.studyEnrollments.first else { // this works bc we only ever enroll into the MHC study.
                     return

--- a/MyHeartCounts/Onboarding/Welcome.swift
+++ b/MyHeartCounts/Onboarding/Welcome.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import SFSafeSymbols
 import Spezi
 import SpeziOnboarding
 import SpeziViews
@@ -23,7 +24,7 @@ struct Welcome: View {
             areas: [
                 OnboardingInformationView.Area(
                     icon: {
-                        Image(systemName: "apps.iphone")
+                        Image(systemSymbol: .appsIphone)
                             .accessibilityHidden(true)
                     },
                     title: "WELCOME_AREA1_TITLE",
@@ -31,7 +32,7 @@ struct Welcome: View {
                 ),
                 OnboardingInformationView.Area(
                     icon: {
-                        Image(systemName: "shippingbox.fill")
+                        Image(systemSymbol: .shippingboxFill)
                             .accessibilityHidden(true)
                     },
                     title: "WELCOME_AREA2_TITLE",
@@ -39,7 +40,7 @@ struct Welcome: View {
                 ),
                 OnboardingInformationView.Area(
                     icon: {
-                        Image(systemName: "list.bullet.clipboard.fill")
+                        Image(systemSymbol: .listBulletClipboardFill)
                             .accessibilityHidden(true)
                     },
                     title: "WELCOME_AREA3_TITLE",

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -2648,13 +2648,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Welcome to the My Heart Counts Cardiovascular Health Study"
+            "value" : "Welcome to the My Heart Counts\nCardiovascular Health Study"
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Welcome to the My Heart Counts Cardiovascular Health Study"
+            "value" : "Welcome to the My Heart Counts\nCardiovascular Health Study"
           }
         },
         "es" : {

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -5,13 +5,34 @@
 
     },
     "- %@" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- %@"
+          }
+        }
+      }
     },
     "– %@" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- %@"
+          }
+        }
+      }
     },
     "—" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—"
+          }
+        }
+      }
     },
     "#=%lld" : {
 
@@ -67,6 +88,24 @@
               }
             }
           }
+        },
+        "es" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%lld missed task in the past 2 weeks"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%lld missed tasks in the past 2 weeks"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -81,58 +120,177 @@
       }
     },
     "$15,000 – $24,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "$15,000 – $24,999"
+          }
+        }
+      }
     },
     "$25,000 – $34,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "$25,000 – $34,999"
+          }
+        }
+      }
     },
     "$35,000 – $49,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "$35,000 – $49,999\n"
+          }
+        }
+      }
     },
     "$50,000 – $74,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "$50,000 – $74,999\n"
+          }
+        }
+      }
     },
     "$75,000 – $99,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "$75,000 – $99,999\n"
+          }
+        }
+      }
     },
     "$100,000 – $149,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "$100,000 – $149,999\n"
+          }
+        }
+      }
     },
     "$150,000 and above" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "$150,000 y más\n"
+          }
+        }
+      }
     },
     "£15,000 – £24,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "£15,000 – £24,999\n"
+          }
+        }
+      }
     },
     "£25,000 – £34,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "£25,000 – £34,999\n"
+          }
+        }
+      }
     },
     "£35,000 – £49,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "£35,000 – £49,999\n"
+          }
+        }
+      }
     },
     "£50,000 – £74,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "£50,000 – £74,999\n"
+          }
+        }
+      }
     },
     "£75,000 – £99,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "£75,000 – £99,999\n"
+          }
+        }
+      }
     },
     "£100,000 – £149,999" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "£100,000 – £149,999\n"
+          }
+        }
+      }
     },
     "£150,000 and above" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "£150,000 y más\n"
+          }
+        }
+      }
     },
     "0" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0"
+          }
+        }
+      }
     },
     "1 to 5 years ago" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 a 5 años atrás\n"
+          }
+        }
+      }
     },
     "12-Minute Run Test (Cooper Test)" : {
 
     },
     "100" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100"
+          }
+        }
+      }
     },
     "About %@" : {
 
@@ -154,7 +312,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Por favor, inicia sesión con tu cuenta. Si aún no tienes una cuenta, regístrateate."
+            "value" : "Por favor, inicie sesión en su cuenta existente. Si no tiene una cuenta existente, por favor regístrese."
           }
         }
       }
@@ -176,7 +334,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Si formasteaste parte del estudio original de My Heart Counts, tu cuenta no se transferirá y necesitarás crear una nueva cuenta."
+            "value" : "Si formó parte del estudio original de My Heart Counts, su cuenta no se transferirá y necesitará crear una nueva cuenta."
           }
         }
       }
@@ -194,38 +352,114 @@
             "state" : "translated",
             "value" : "You are already logged in with the account shown below. Continue or change your account by logging out."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ya ha iniciado sesión con la cuenta que se muestra a continuación. Continúe o cambie su cuenta cerrando sesión."
+          }
         }
       }
     },
     "Actively smoking" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fumar activamente\n"
+          }
+        }
+      }
     },
     "Add" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar"
+          }
+        }
+      }
     },
     "Add Data" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar Datos\n"
+          }
+        }
+      }
     },
     "Add Height & Weight Samples" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar Muestras de Altura y Peso\n"
+          }
+        }
+      }
     },
     "Add Sample" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar Muestra\n"
+          }
+        }
+      }
     },
     "Age" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edad"
+          }
+        }
+      }
     },
     "Alabama" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alabama"
+          }
+        }
+      }
     },
     "Alaska" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alaska"
+          }
+        }
+      }
     },
     "All Samples" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todas las Muestras\n"
+          }
+        }
+      }
     },
     "All tasks have been completed!" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Todas las tareas han sido completadas!\n"
+          }
+        }
+      }
     },
     "Allow Notifications" : {
       "localizations" : {
@@ -244,41 +478,97 @@
       }
     },
     "American Samoa" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Samoa Americana\n"
+          }
+        }
+      }
     },
     "App Usage" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uso de la aplicación\n"
+          }
+        }
+      }
     },
     "Are you %lld years old or older?" : {
       "localizations" : {
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Tienes %lld años o más?"
+            "value" : "¿Tiene %lld años o más?"
           }
         }
       }
     },
     "Are you able to perform physical activities?" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Eres capaz de realizar actividades físicas?\n"
+          }
+        }
+      }
     },
     "Are you Hispanic/Latino?" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Eres hispano/latino?\n"
+          }
+        }
+      }
     },
     "Are you sure you want to leave the '%@' study?" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Estás seguro de que deseas abandonar el estudio de '%@'?\n"
+          }
+        }
+      }
     },
     "Arizona" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arizona"
+          }
+        }
+      }
     },
     "Arkansas" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arkansas"
+          }
+        }
+      }
     },
     "AuthorizationStatus" : {
 
     },
     "Biological Sex at Birth" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sexo Biológico al Nacer\n"
+          }
+        }
+      }
     },
     "Blood Lipids" : {
       "localizations" : {
@@ -291,35 +581,84 @@
       }
     },
     "Blood Type" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de Sangre\n"
+          }
+        }
+      }
     },
     "Bulk Export Manager" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerente de Exportación Masiva\n"
+          }
+        }
+      }
     },
     "bundle id" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "id de paquete\n"
+          }
+        }
+      }
     },
     "California" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "California\n"
+          }
+        }
+      }
     },
     "Can you read and understand %@ in order to provide informed consent and follow instructions?" : {
       "localizations" : {
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Puedes leer y entender %@ para proporcionar tu consentimiento informado y seguir las instrucciones?\n"
+            "value" : "¿Puede leer y entender %@ para proporcionar su consentimiento informado y seguir las instrucciones?"
           }
         }
       }
     },
     "Cancel" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        }
+      }
     },
     "Change Language" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar Idioma\n"
+          }
+        }
+      }
     },
     "chromaticity" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cromaticidad"
+          }
+        }
+      }
     },
     "Close" : {
       "localizations" : {
@@ -328,14 +667,34 @@
             "state" : "translated",
             "value" : "Close"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar"
+          }
         }
       }
     },
     "Colorado" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colorado"
+          }
+        }
+      }
     },
     "Comorbidities" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comorbilidades"
+          }
+        }
+      }
     },
     "COMORBIDITY_ACHD" : {
       "localizations" : {
@@ -349,6 +708,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Adult Congenital Heart Disease"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enfermedad Cardíaca Congénita en Adultos\n"
           }
         }
       }
@@ -366,6 +731,12 @@
             "state" : "translated",
             "value" : "Coronary Artery Disease"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enfermedad Arterial Coronaria\n"
+          }
         }
       }
     },
@@ -378,6 +749,12 @@
           }
         },
         "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diabetes"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Diabetes"
@@ -398,6 +775,12 @@
             "state" : "translated",
             "value" : "Heart Failure"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insuficiencia Cardíaca\n"
+          }
         }
       }
     },
@@ -413,6 +796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "None"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ninguno"
           }
         }
       }
@@ -430,14 +819,34 @@
             "state" : "translated",
             "value" : "Pulmonary Arterial Hypertension"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hipertensión Arterial Pulmonar\n"
+          }
         }
       }
     },
     "Companion Watch App Not Installed" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicación de Reloj Complementario No Instalada\n"
+          }
+        }
+      }
     },
     "Complete" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completo"
+          }
+        }
+      }
     },
     "COMPREHENSION_QUESTION_1" : {
       "localizations" : {
@@ -478,7 +887,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No estoy obligado/a a completar todas o ninguna de las partes de este estudio si no quiero."
+            "value" : "No estoy obligado a completar todas o ninguna de las partes de este estudio si no quiero."
           }
         }
       }
@@ -522,7 +931,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Por favor, responde algunas preguntas de repaso para asegurarnos de que entiende el formulario de consentimiento."
+            "value" : "Por favor, responda algunas preguntas de repaso para asegurarse de que entiende el formulario de consentimiento."
           }
         }
       }
@@ -553,64 +962,204 @@
 
     },
     "Connecticut" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "conficence"
+          }
+        }
+      }
     },
     "Consent" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consentimiento"
+          }
+        }
+      }
     },
     "Consent Date" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de Consentimiento\n"
+          }
+        }
+      }
     },
     "Consent Documents" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Documentos de Consentimiento\n"
+          }
+        }
+      }
     },
     "Consent Renewal" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renovación de Consentimiento\n"
+          }
+        }
+      }
     },
     "Consent Version" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión de Consentimiento\n"
+          }
+        }
+      }
     },
     "Continue" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar"
+          }
+        }
+      }
     },
     "County" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Condado"
+          }
+        }
+      }
     },
     "crownOrientation" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "orientación de la corona\n"
+          }
+        }
+      }
     },
     "Current Test" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prueba Actual\n"
+          }
+        }
+      }
     },
     "date" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "fecha"
+          }
+        }
+      }
     },
     "Date" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha"
+          }
+        }
+      }
     },
     "Date of Birth" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de Nacimiento\n"
+          }
+        }
+      }
     },
     "Debug" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depurar"
+          }
+        }
+      }
     },
     "Debug Options" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opciones de Depuración\n"
+          }
+        }
+      }
     },
     "Delaware" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delaware"
+          }
+        }
+      }
     },
     "Delete ~/%@/*" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar ~/%@/*"
+          }
+        }
+      }
     },
     "Delete&Reset Session" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar y Restablecer Sesión\n"
+          }
+        }
+      }
     },
     "Demographics" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demografía"
+          }
+        }
+      }
     },
     "Depending on the amount of samples, this might take a bit" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dependiendo de la cantidad de muestras, esto podría tardar un poco.\n"
+          }
+        }
+      }
     },
     "Diet" : {
       "localizations" : {
@@ -623,16 +1172,44 @@
       }
     },
     "Disable Override" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable Override\t"
+          }
+        }
+      }
     },
     "Disclosure Indicator" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicador de Divulgación\n"
+          }
+        }
+      }
     },
     "District of Columbia" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distrito de Columbia\n"
+          }
+        }
+      }
     },
     "Done" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hecho"
+          }
+        }
+      }
     },
     "ECG_INSTRUCTIONS_TEXT" : {
       "localizations" : {
@@ -680,10 +1257,24 @@
       }
     },
     "Educational Level" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivel Educativo\n"
+          }
+        }
+      }
     },
     "Effective Region" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Región Efectiva\n"
+          }
+        }
+      }
     },
     "ELIGIBILITY_STEP_SUBTITLE" : {
       "localizations" : {
@@ -702,7 +1293,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Antes de comenzar, te haremos unas preguntas rápidas para asegurarnos que el estudio sea adecuado para ti."
+            "value" : "Antes de comenzar, le haremos unas preguntas rápidas para asegurarnos de que el estudio sea adecuado para usted."
           }
         }
       }
@@ -730,40 +1321,124 @@
       }
     },
     "Enable App Debug Mode" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habilitar Modo de Depuración de la Aplicación\n"
+          }
+        }
+      }
     },
     "End Study Participation" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizar Participación en el Estudio\n"
+          }
+        }
+      }
     },
     "Enroll in Study" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inscribirse en el Estudio\n"
+          }
+        }
+      }
     },
     "Enrolled since: %@" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inscrito desde: %@"
+          }
+        }
+      }
     },
     "Enter Blood Pressure" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresar Presión Arterial\n"
+          }
+        }
+      }
     },
     "Enter BMI" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresar IMC (Índice de Masa Corporal)\n"
+          }
+        }
+      }
     },
     "Enter Height" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresar Altura\n"
+          }
+        }
+      }
     },
     "Enter Weight" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresar Peso\n"
+          }
+        }
+      }
     },
     "Error" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error\n"
+          }
+        }
+      }
     },
     "Failed to Download Study Information" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falló al Descargar Información del Estudio\n"
+          }
+        }
+      }
     },
     "Failed to Load Study into App" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falló al Cargar el Estudio en la Aplicación\n"
+          }
+        }
+      }
     },
     "Failed to process Sleep Sessions" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falló al procesar las Sesiones de Sueño\n"
+          }
+        }
+      }
     },
     "False" : {
       "localizations" : {
@@ -776,10 +1451,24 @@
       }
     },
     "FCM Token" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token de FCM\n"
+          }
+        }
+      }
     },
     "Feedback" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retroalimentación\n"
+          }
+        }
+      }
     },
     "FEEDBACK_FORM_FOOTER_TEXT" : {
       "localizations" : {
@@ -798,22 +1487,64 @@
       }
     },
     "Feel free to check back later!" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Siéntete libre de volver más tarde!\n"
+          }
+        }
+      }
     },
     "Fetch Results" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener Resultados\n"
+          }
+        }
+      }
     },
     "Fetch WristTemp Data" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener Datos de Temperatura de Muñeca\n"
+          }
+        }
+      }
     },
     "Fetching Data…" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obteniendo Datos…\n"
+          }
+        }
+      }
     },
     "Fetching…" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obteniendo…\n"
+          }
+        }
+      }
     },
     "Filter Options" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opciones de Filtro\n"
+          }
+        }
+      }
     },
     "FINAL_ENROLLMENT_STEP_MESSAGE" : {
       "localizations" : {
@@ -872,29 +1603,84 @@
             "state" : "translated",
             "value" : "After your baseline week, you'll begin the 2-week trial comparing different types of physical activity coaching. You'll receive notifications when this phase begins."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Después de tu semana basal, comenzarás el ensayo de 2 semanas comparando diferentes tipos de entrenamiento de actividad física. Recibirás notificaciones cuando esta fase comience.\n"
+          }
         }
       }
     },
     "First 3 Digits of ZIP Code" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primeros 3 Dígitos del Código Postal\n"
+          }
+        }
+      }
     },
     "First half of Postcode" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primera mitad del Código Postal\n"
+          }
+        }
+      }
     },
     "Florida" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Florida"
+          }
+        }
+      }
     },
     "For optimal results, please keep your Phone in your pocket, and %@ until it vibrates to indicate that the test has ended." : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para obtener resultados óptimos, por favor, mantén tu teléfono en tu bolsillo y %@ hasta que vibre indicando que la prueba ha terminado.\n"
+          }
+        }
+      }
     },
     "For optimal results, please keep your Phone in your pocket, and %@ until your Watch vibrates to indicate that the test has ended." : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para obtener resultados óptimos, por favor, mantén tu teléfono en tu bolsillo y %@ hasta que tu reloj vibre indicando que la prueba ha terminado.\n"
+          }
+        }
+      }
     },
     "Future Studies" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estudios Futuros\n"
+          }
+        }
+      }
     },
     "Gender Identity" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Identidad de Género\n"
+          }
+        }
+      }
     },
     "GENDER_FEMALE" : {
       "localizations" : {
@@ -908,6 +1694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Female"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Femenino\n"
           }
         }
       }
@@ -925,6 +1717,12 @@
             "state" : "translated",
             "value" : "Male"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hombre"
+          }
         }
       }
     },
@@ -940,6 +1738,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gender Variant / Non-Conforming"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Variante de género / No conforme\n"
           }
         }
       }
@@ -957,6 +1761,12 @@
             "state" : "translated",
             "value" : "Prefer not to state"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefiero no declarar\n"
+          }
         }
       }
     },
@@ -972,6 +1782,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Transgender Female"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mujer transgénero\n"
           }
         }
       }
@@ -989,17 +1805,44 @@
             "state" : "translated",
             "value" : "Transgender Male"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hombre transgénero\n"
+          }
         }
       }
     },
     "Georgia" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Georgia"
+          }
+        }
+      }
     },
     "Go to next field" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ir al siguiente campo\n"
+          }
+        }
+      }
     },
     "Go to previous field" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ir al campo anterior\n"
+          }
+        }
+      }
     },
     "Grant Access" : {
       "localizations" : {
@@ -1008,20 +1851,54 @@
             "state" : "translated",
             "value" : "Grant Access"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conceder acceso\n"
+          }
         }
       }
     },
     "Guam" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guam"
+          }
+        }
+      }
     },
     "Hawaii" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hawái"
+          }
+        }
+      }
     },
     "Health Data" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datos de salud\n"
+          }
+        }
+      }
     },
     "Health Data Bulk Upload" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carga masiva de datos de salud\n"
+          }
+        }
+      }
     },
     "HealthKit Access" : {
       "localizations" : {
@@ -1029,6 +1906,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "HealthKit Access"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acceso a HealthKit\n"
           }
         }
       }
@@ -1062,11 +1945,24 @@
             "state" : "translated",
             "value" : "The My Heart Counts Study uses Health Data collected on your iPhone to further our research goals. Granting access to all fields (or as many as you are comfortable with) ensures the most well powered study possible."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El Estudio Mi Corazón Cuenta utiliza Datos de Salud recopilados en tu iPhone para avanzar en nuestros objetivos de investigación. Conceder acceso a todos los campos (o a tantos como te sientas cómodo) asegura que el estudio esté lo más optimizado posible."
+          }
         }
       }
     },
     "Heart Health" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salud del Corazón"
+          }
+        }
+      }
     },
     "Heart Health Dashboard" : {
       "localizations" : {
@@ -1101,52 +1997,150 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tu puntuación personalizada refleja tu salud general basada en los factores que se enumeran a continuación. Síguela con el tiempo para ver cómo los cambios en el estilo de vida afectan la salud de su corazón."
+            "value" : "Su puntuación personalizada refleja su salud general basada en los factores que se enumeran a continuación. Sígala con el tiempo para ver cómo los cambios en el estilo de vida afectan la salud de su corazón."
           }
         }
       }
     },
     "Height" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura"
+          }
+        }
+      }
     },
     "Household Income" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingreso Familiar\n"
+          }
+        }
+      }
     },
     "I have never smoked" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nunca he fumado\n"
+          }
+        }
+      }
     },
     "I last smoked between 1 and 5 years ago" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fumé por última vez entre 1 y 5 años atrás\n"
+          }
+        }
+      }
     },
     "I last smoked more than 5 years ago" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fumé por última vez hace más de 5 años\n"
+          }
+        }
+      }
     },
     "I last smoked within the last year, or am using NDS" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fumé por última vez en el último año, o estoy usando NDS\n"
+          }
+        }
+      }
     },
     "I'm actively smoking" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estoy fumando activamente\n"
+          }
+        }
+      }
     },
     "id" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "id"
+          }
+        }
+      }
     },
     "Idaho" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idaho"
+          }
+        }
+      }
     },
     "identifier" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "identificador\n"
+          }
+        }
+      }
     },
     "If you have an Apple Watch, please ensure that the My Heart Counts app is running" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si tienes un Apple Watch, asegúrate de que la aplicación Mi Corazón Cuenta esté en funcionamiento\n"
+          }
+        }
+      }
     },
     "Ignore Empty Fetch Results" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorar Resultados Vacíos\n"
+          }
+        }
+      }
     },
     "Illinois" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Illinois"
+          }
+        }
+      }
     },
     "Indiana" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indiana"
+          }
+        }
+      }
     },
     "INELIGIBLE_LEARN_MORE" : {
       "localizations" : {
@@ -1159,7 +2153,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obtén más información sobre My Heart Counts."
+            "value" : "Obtenga más información sobre My Heart Counts."
           }
         }
       }
@@ -1175,7 +2169,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No eresre apto/a para participar en este estudio porque no cumpless con los criterios de admisión."
+            "value" : "No es elegible para participar en este estudio porque no cumple con los criterios de elegibilidad."
           }
         }
       }
@@ -1191,34 +2185,90 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No Apto para Participar"
+            "value" : "No Elegible para Participar"
           }
         }
       }
     },
     "Install on Apple Watch" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instalar en Apple Watch\n"
+          }
+        }
+      }
     },
     "Installing My Heart Counts on your Apple Watch will allow us to greatly increase the quality of the recorded data." : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instalar Mi Corazón Cuenta en tu Apple Watch nos permitirá aumentar considerablemente la calidad de los datos registrados.\n"
+          }
+        }
+      }
     },
     "Iowa" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iowa"
+          }
+        }
+      }
     },
     "Kansas" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kansas"
+          }
+        }
+      }
     },
     "Kentucky" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kentucky"
+          }
+        }
+      }
     },
     "Language" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idioma"
+          }
+        }
+      }
     },
     "Latino / Hispanic?" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Latino / Hispano?\n"
+          }
+        }
+      }
     },
     "Launch Watch App" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar la Aplicación del Reloj\n"
+          }
+        }
+      }
     },
     "Learn More" : {
       "localizations" : {
@@ -1227,14 +2277,34 @@
             "state" : "translated",
             "value" : "Learn More"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aprender Más\n"
+          }
         }
       }
     },
     "Less than $15,000" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menos de $15,000\n"
+          }
+        }
+      }
     },
     "Less than £15,000" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menos de £15,000\n"
+          }
+        }
+      }
     },
     "License Information" : {
       "localizations" : {
@@ -1243,68 +2313,214 @@
             "state" : "translated",
             "value" : "License Information"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Información de Licencia\n"
+          }
         }
       }
     },
     "Link Arrow Symbol" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Símbolo de Flecha de Enlace\n"
+          }
+        }
+      }
     },
     "Live Health Upload Notifications" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notificaciones de Carga de Salud en Vivo\n"
+          }
+        }
+      }
     },
     "Loading Firebase Test Setup" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando Configuración de Prueba de Firebase\n"
+          }
+        }
+      }
     },
     "Local Notifications Status" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado de Notificaciones Locales\n"
+          }
+        }
+      }
     },
     "locationCategory" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "categoríaDeUbicación"
+          }
+        }
+      }
     },
     "Louisiana" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Luisiana"
+          }
+        }
+      }
     },
     "Maine" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maine"
+          }
+        }
+      }
     },
     "Make sure your device is connected to the internet and try again" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asegúrate de que tu dispositivo esté conectado a Internet y vuelve a intentarlo\n"
+          }
+        }
+      }
     },
     "Maryland" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maryland"
+          }
+        }
+      }
     },
     "Massachusetts" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Massachusetts"
+          }
+        }
+      }
     },
     "Matching Entry" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrada Coincidente\n"
+          }
+        }
+      }
     },
     "May we contact you about future studies that may be of interest to you?" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Podemos ponernos en contacto contigo sobre estudios futuros que puedan interesarte?\n"
+          }
+        }
+      }
     },
     "Michigan" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Michigan"
+          }
+        }
+      }
     },
     "Minnesota" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minnesota"
+          }
+        }
+      }
     },
     "Missed Tasks" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tareas Perdidas\n"
+          }
+        }
+      }
     },
     "Missing Required Motion Data Access Permission" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faltando Permiso de Acceso a Datos de Movimiento Requerido\n"
+          }
+        }
+      }
     },
     "Mississippi" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Misisipí"
+          }
+        }
+      }
     },
     "Missouri" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Misuri"
+          }
+        }
+      }
     },
     "Montana" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Montana"
+          }
+        }
+      }
     },
     "More than 5 years ago" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hace más de 5 años\n"
+          }
+        }
+      }
     },
     "My Heart Counts" : {
       "localizations" : {
@@ -1317,43 +2533,120 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mi Corazón Cuenta"
+            "value" : "My Heart Counts"
           }
         }
       }
     },
     "n/a" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "n/a"
+          }
+        }
+      }
     },
     "Nebraska" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nebraska"
+          }
+        }
+      }
     },
     "Network Issue" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Problema de Red\n"
+          }
+        }
+      }
     },
     "Nevada" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nevada\n"
+          }
+        }
+      }
     },
     "Never" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nunca"
+          }
+        }
+      }
     },
     "New Hampshire" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nueva Hampshire\n"
+          }
+        }
+      }
     },
     "New Jersey" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nueva Jersey\n"
+          }
+        }
+      }
     },
     "New Mexico" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuevo México\n"
+          }
+        }
+      }
     },
     "New York" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nueva York\n"
+          }
+        }
+      }
     },
     "News" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noticias"
+          }
+        }
+      }
     },
     "News & Information" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noticias e Información\n"
+          }
+        }
+      }
     },
     "Next" : {
       "localizations" : {
@@ -1362,14 +2655,34 @@
             "state" : "translated",
             "value" : "Next"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siguiente"
+          }
         }
       }
     },
     "NHS Number" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Número NHS\n"
+          }
+        }
+      }
     },
     "NHS Number (Optional)" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Número NHS (Opcional)\n"
+          }
+        }
+      }
     },
     "Nicotine Exposure" : {
       "localizations" : {
@@ -1392,37 +2705,114 @@
       }
     },
     "No Data" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin Datos\n"
+          }
+        }
+      }
     },
     "No Internet" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin Internet\n"
+          }
+        }
+      }
     },
     "No Missed Tasks" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay Tareas Perdidas\n"
+          }
+        }
+      }
     },
     "No News Yet" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay Noticias Aún\n"
+          }
+        }
+      }
     },
     "No Upcoming Tasks" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay Tareas Próximas\n"
+          }
+        }
+      }
     },
     "No, not Spanish/Hispanic/Latino" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No, no soy hispano/latino\n"
+          }
+        }
+      }
     },
     "North Carolina" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carolina del Norte\n"
+          }
+        }
+      }
     },
     "North Dakota" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dakota del Norte\n"
+          }
+        }
+      }
     },
     "Northern Mariana Islands" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Islas Marianas del Norte\n"
+          }
+        }
+      }
     },
     "Not logged in" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No ha iniciado sesión\n"
+          }
+        }
+      }
     },
     "Not Set" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Establecido\n"
+          }
+        }
+      }
     },
     "NOTIFICATION_PERMISSIONS_DESCRIPTION" : {
       "localizations" : {
@@ -1441,7 +2831,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Por favor, permite que My Heart Counts te envíe notificaciones para que podamos llevar a cabo la investigación de manera adecuada.\n\nMantenedremos las notificaciones al mínimo.\n"
+            "value" : "Por favor, permita que My Heart Counts le envíe notificaciones para que podamos llevar a cabo la investigación de manera adecuada.\n\nHaremos nuestro mejor esfuerzo para mantener las notificaciones al mínimo."
           }
         }
       }
@@ -1463,19 +2853,47 @@
       }
     },
     "Notifications Status" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado de Notificaciones\n"
+          }
+        }
+      }
     },
     "offWristDate" : {
 
     },
     "Ohio" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ohio\n"
+          }
+        }
+      }
     },
     "OK" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
     },
     "Oklahoma" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oklahoma\n"
+          }
+        }
+      }
     },
     "ONBOARDING_DISCLAIMER_1_LEARN_MORE_TEXT" : {
       "localizations" : {
@@ -1494,7 +2912,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este estudio de investigación es realizado por investigadores de la Escuela de Medicina de la Universidad de Stanford para entender cómo la actividad física se relaciona con la salud cardiovascular. La aplicación te guiará a través de varias evaluaciones, incluyendo la prueba de caminata de 6 minutos. Tu participación es flexible, lo que significa que puedes participar en el estudio tanto como desees o tan poco como elijas. El enfoque basado en el smartphone nos permite recopilar datos en tu entorno natural en lugar de requerir visitas a una instalación clínica."
+            "value" : "Este estudio de investigación es llevado a cabo por investigadores de la Facultad de Medicina de la Universidad de Stanford para entender cómo la actividad física se relaciona con la salud cardiovascular. La aplicación te guiará a través de varias evaluaciones, incluyendo la prueba de caminata de 6 minutos. Tu participación es flexible, lo que significa que puedes participar en el estudio tanto como desees. El enfoque basado en teléfonos inteligentes nos permite recopilar datos en tu entorno natural en lugar de requerir visitas a una instalación clínica.\n"
           }
         }
       }
@@ -1516,7 +2934,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Te invitamos a unirte a un estudio de investigación de Stanford que rastrea la actividad física a través de tu smartphone para mejorar el conocimiento sobre la salud del corazón. \n\nSolo necesitas completar breves encuestas sobre tu salud y realizar evaluaciones de condición física simples como una prueba de esfuerzo de 6 minutos usando tu teléfono."
+            "value" : "Usted está invitado a unirse a un estudio de investigación de Stanford que rastrea la actividad física a través de su teléfono inteligente para mejorar el conocimiento sobre la salud del corazón. Completará breves encuestas de salud y realizará evaluaciones de condición física simples como la prueba de caminata de 6 minutos usando su teléfono."
           }
         }
       }
@@ -1554,7 +2972,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El ensayo opcional utiliza un diseño de \"cruce aleatorio\" donde experimentarás ambos tipos de intervenciones de coaching: comandos de actividad personalizados y comandos de actividad estándar, durante 7 días cada uno (un total de 14 días). Esto comenzará después de la semana de monitoreo inicial. El orden en el que recibas estas intervenciones será asignado aleatoriamente, similar a lanzar una moneda. Este diseño permite a los investigadores comparar cómo los diferentes enfoques de coaching afectan tus niveles de actividad mientras se controlan las diferencias individuales, ya que cada participante sirve como su propio control. Puedes optar por no participar en este componente del ensayo y aún ser parte del estudio principal My Heart Counts."
+            "value" : "El ensayo opcional utiliza un diseño de \"cruce aleatorio\" en el que experimentarás ambos tipos de intervenciones de coaching: indicaciones de actividad personalizadas e indicaciones de actividad estándar, durante 7 días cada una (un total de 14 días). Esto comenzará después de la semana de monitoreo de referencia. El orden en que recibas estas intervenciones se asignará de manera aleatoria, similar a lanzar una moneda. Este diseño permite a los investigadores comparar cómo los diferentes enfoques de coaching afectan tus niveles de actividad mientras controlan las diferencias individuales, ya que cada participante actúa como su propio control. Puedes optar por no participar en este componente del ensayo y seguir siendo parte del estudio principal My Heart Counts."
           }
         }
       }
@@ -1610,6 +3028,12 @@
             "state" : "translated",
             "value" : "The study collects data through your phone's sensors, including accelerometer data for movement, GPS for location during specific fitness tests, and heart rate if available through connected devices. All data transmission uses encryption technology to protect your information. We separate your identifying information from your health data in our secure databases. You'll have options within the app to control what information is shared We follow strict protocols approved by Stanford's Institutional Review Board to maintain your privacy."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El estudio recopila datos a través de los sensores de tu teléfono, incluidos los datos del acelerómetro para el movimiento, el GPS para la ubicación durante pruebas de fitness específicas y la frecuencia cardíaca si está disponible a través de dispositivos conectados. Toda la transmisión de datos utiliza tecnología de cifrado para proteger tu información. Separamos tu información identificativa de tus datos de salud en nuestras bases de datos seguras. Tendrás opciones dentro de la aplicación para controlar qué información se comparte. Seguimos protocolos estrictos aprobados por la Junta de Revisión Institucional de Stanford para mantener tu privacidad."
+          }
         }
       }
     },
@@ -1630,7 +3054,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recopilaremos datos de la aplicación Salud en tu iPhone, los cuales estarán protegidos mediante encriptación. Tu información personal se almacena por separado de los datos de salud, y podrás controlar qué datos de sensores y salud compartes con nosotros.\n\nAl aceptar este consentimiento, tus datos se combinarán con datos de otros participantes para ser analizados por los investigadores de Stanford y sus socios de investigación."
+            "value" : "Recopilaremos datos de la aplicación Salud en su iPhone, los cuales estarán protegidos mediante cifrado. Su información personal se almacena separadamente de los datos de salud, y usted controla qué datos de sensores y salud comparte con nosotros.\n\nAl aceptar este consentimiento, sus datos se combinarán con datos de otros participantes para ser analizados por los investigadores de Stanford y sus socios de investigación."
           }
         }
       }
@@ -1674,7 +3098,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Los riesgos físicos son mínimos pero podrían incluir dolor muscular temporal o tensión debido a las actividades físicas. También hay un pequeño riesgo relacionado con la privacidad de los datos a pesar de nuestras medidas de seguridad. Los beneficios incluyen el acceso a tus propios datos de actividad y el conocimiento de que estás contribuyendo a una investigación que puede ayudar a mejorar las recomendaciones de salud cardíaca. Tu participación es completamente voluntaria y puedes dejar de participar en cualquier momento sin penalización contactando al equipo de investigación. Esta investigación ha sido revisada por la Comité de Ética en Investigación (CEI) de Stanford para asegurar la protección de los participantes."
+            "value" : "Los riesgos físicos son mínimos, pero podrían incluir dolor o tensión muscular temporal debido a actividades físicas. También hay un pequeño riesgo relacionado con la privacidad de los datos a pesar de nuestras medidas de seguridad. Los beneficios incluyen acceso a tus propios datos de actividad y el conocimiento de que estás contribuyendo a una investigación que puede ayudar a mejorar las recomendaciones sobre la salud del corazón. Tu participación es completamente voluntaria, y puedes dejar de participar en cualquier momento sin penalización contactando al equipo de investigación. Esta investigación ha sido revisada por la Junta de Revisión Institucional de Stanford para garantizar la protección de los participantes."
           }
         }
       }
@@ -1730,28 +3154,84 @@
 
     },
     "Open In Browser" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir en el navegador\n"
+          }
+        }
+      }
     },
     "Open Settings" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir configuración\n"
+          }
+        }
+      }
     },
     "Oregon" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oregón\n"
+          }
+        }
+      }
     },
     "Other Territories" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otros territorios\n"
+          }
+        }
+      }
     },
     "Our Study Consent document has been updated since you last signed it%@.\n\nPlease review the new Consent document and sign it again." : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuestro documento de consentimiento del estudio ha sido actualizado desde la última vez que lo firmaste %@.\n\nPor favor, revisa el nuevo documento de consentimiento y fírmalo nuevamente.\n"
+          }
+        }
+      }
     },
     "Override Region" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anular región\n"
+          }
+        }
+      }
     },
     "Participation Criteria" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criterios de participación\n"
+          }
+        }
+      }
     },
     "Past Data" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datos pasados\n"
+          }
+        }
+      }
     },
     "PAST_TIMED_WALKING_RUNNING_TEST_RESULTS_BUTTON_TITLE" : {
       "localizations" : {
@@ -1766,35 +3246,104 @@
             "state" : "translated",
             "value" : "Past Timed Walk/Run Test Results"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resultados de pruebas de caminata/corrida cronometradas pasadas\n"
+          }
         }
       }
     },
     "Pennsylvania" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pensilvania"
+          }
+        }
+      }
     },
     "Percentage in Phase" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Porcentaje en fase\n"
+          }
+        }
+      }
     },
     "Permissions" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permisos"
+          }
+        }
+      }
     },
     "Physical Activity" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividad Física\n"
+          }
+        }
+      }
     },
     "placement" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colocación"
+          }
+        }
+      }
     },
     "Processing Health Data…" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Procesando datos de salud...\n"
+          }
+        }
+      }
     },
     "Processing Sleep Data…" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Procesando datos de sueño...\n"
+          }
+        }
+      }
     },
     "Puerto Rico" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puerto Rico\n"
+          }
+        }
+      }
     },
     "Race / Ethnicity" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raza / Etnicidad\n"
+          }
+        }
+      }
     },
     "RACE_AFRICAN_AMERICAN" : {
       "localizations" : {
@@ -1808,6 +3357,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "African American"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afroamericano\n"
           }
         }
       }
@@ -1825,6 +3380,12 @@
             "state" : "translated",
             "value" : "Alaska Native"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nativo de Alaska\n"
+          }
         }
       }
     },
@@ -1840,6 +3401,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "American Indian"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indígena Americano\n"
           }
         }
       }
@@ -1857,6 +3424,12 @@
             "state" : "translated",
             "value" : "Asian Indian"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indio Asiático\n"
+          }
         }
       }
     },
@@ -1873,6 +3446,12 @@
             "state" : "translated",
             "value" : "Chinese"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chino"
+          }
         }
       }
     },
@@ -1885,6 +3464,12 @@
           }
         },
         "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filipino"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filipino"
@@ -1905,6 +3490,12 @@
             "state" : "translated",
             "value" : "Japanese"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japonés"
+          }
         }
       }
     },
@@ -1920,6 +3511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Korean"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coreano"
           }
         }
       }
@@ -1937,6 +3534,12 @@
             "state" : "translated",
             "value" : "No Selection"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin selección\n"
+          }
         }
       }
     },
@@ -1952,6 +3555,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Other"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otro"
           }
         }
       }
@@ -1969,6 +3578,12 @@
             "state" : "translated",
             "value" : "Pacific Islander"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Isleño del Pacífico\n"
+          }
         }
       }
     },
@@ -1984,6 +3599,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prefer not to Answer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefiero no responder\n"
           }
         }
       }
@@ -2001,6 +3622,12 @@
             "state" : "translated",
             "value" : "You can select multiple options."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puedes seleccionar múltiples opciones.\n"
+          }
         }
       }
     },
@@ -2016,6 +3643,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vietnamese"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vietnamita\n"
           }
         }
       }
@@ -2033,95 +3666,283 @@
             "state" : "translated",
             "value" : "White"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blanco"
+          }
         }
       }
     },
     "Read Article" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leer artículo\n"
+          }
+        }
+      }
     },
     "Read from Health App" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leer desde la aplicación de salud\n"
+          }
+        }
+      }
     },
     "Recent Sleep Data" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datos recientes de sueño\n"
+          }
+        }
+      }
     },
     "Region" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Región"
+          }
+        }
+      }
     },
     "Remote Notifications Registration" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registro de Notificaciones Remotas\n"
+          }
+        }
+      }
     },
     "Replace Root View Controller" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reemplazar el Controlador de Vista Raíz\n"
+          }
+        }
+      }
     },
     "reportApplicationIdentifier" : {
 
     },
     "Request Permissions" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitar Permisos\n"
+          }
+        }
+      }
     },
     "Results" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resultados\n"
+          }
+        }
+      }
     },
     "Retry" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reintentar\n"
+          }
+        }
+      }
     },
     "Review Consent Forms" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisar Formularios de Consentimiento\n"
+          }
+        }
+      }
     },
     "Rhode Island" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rhode Island\n"
+          }
+        }
+      }
     },
     "run" : {
 
     },
     "Sample" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra\n"
+          }
+        }
+      }
     },
     "Sample Type" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de Muestra\n"
+          }
+        }
+      }
     },
     "sampleType" : {
 
     },
     "Save" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar"
+          }
+        }
+      }
     },
     "Scheduled Local Notifications" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notificaciones Locales Programadas\n"
+          }
+        }
+      }
     },
     "Score Result" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resultado de Puntaje\n"
+          }
+        }
+      }
     },
     "Select a Region" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona una Región\n"
+          }
+        }
+      }
     },
     "Select County" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona un Condado\n"
+          }
+        }
+      }
     },
     "Select your State or Territory" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona tu Estado o Territorio\n"
+          }
+        }
+      }
     },
     "Selected" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionado"
+          }
+        }
+      }
     },
     "Selection" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selección"
+          }
+        }
+      }
     },
     "Selection Checkmark" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marca de selección\n"
+          }
+        }
+      }
     },
     "Send" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar\n"
+          }
+        }
+      }
     },
     "Send Feedback" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar Comentarios\n"
+          }
+        }
+      }
     },
     "Sensors" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sensores\n"
+          }
+        }
+      }
     },
     "Series" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Series"
+          }
+        }
+      }
     },
     "SEX_FEMALE" : {
       "localizations" : {
@@ -2135,6 +3956,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Female"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Femenino"
           }
         }
       }
@@ -2152,6 +3979,12 @@
             "state" : "translated",
             "value" : "Intersex"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intersex\n"
+          }
         }
       }
     },
@@ -2167,6 +4000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Male"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masculino"
           }
         }
       }
@@ -2184,38 +4023,114 @@
             "state" : "translated",
             "value" : "Prefer not to state"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefiero no declarar\n"
+          }
         }
       }
     },
     "Sleep Phase" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fase del Sueño\n"
+          }
+        }
+      }
     },
     "South Carolina" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carolina del Sur\n"
+          }
+        }
+      }
     },
     "South Dakota" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dakota del Sur\n"
+          }
+        }
+      }
     },
     "Start All" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar Todo\n"
+          }
+        }
+      }
     },
     "Start Test" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar Prueba\n"
+          }
+        }
+      }
     },
     "State" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado"
+          }
+        }
+      }
     },
     "Stop All" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detener Todo\n"
+          }
+        }
+      }
     },
     "Study Information" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Información del Estudio\n"
+          }
+        }
+      }
     },
     "Study not available" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estudio no disponible\n"
+          }
+        }
+      }
     },
     "Study Participation" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Participación en el Estudio\n"
+          }
+        }
+      }
     },
     "Summarized" : {
       "localizations" : {
@@ -2224,62 +4139,187 @@
             "state" : "translated",
             "value" : "Summarised"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resumido"
+          }
         }
       }
     },
     "Supplemental Categories" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Categorías Suplementarias\n"
+          }
+        }
+      }
     },
     "Take Test" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Realizar Prueba\n"
+          }
+        }
+      }
     },
     "Tap to enter data…" : {
 
     },
     "Tennessee" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tennessee"
+          }
+        }
+      }
     },
     "Test" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prueba\n"
+          }
+        }
+      }
     },
     "Testing Support" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soporte de Pruebas\n"
+          }
+        }
+      }
     },
     "Texas" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texas"
+          }
+        }
+      }
     },
     "The app was able to download the study, but failed to decode it.\nMake sure you have the newest version installed." : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La aplicación pudo descargar el estudio, pero no pudo decodificarlo. Asegúrate de tener instalada la versión más reciente.\n"
+          }
+        }
+      }
     },
     "The app was unable to load the study, but we're not sure why" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La aplicación no pudo cargar el estudio, pero no estamos seguros de por qué\n"
+          }
+        }
+      }
     },
     "The Timed Walking Test requires read access to Motion and Fitness Data." : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La Prueba de Caminata cronometrada requiere acceso de lectura a los Datos de Movimiento y Fitness.\n"
+          }
+        }
+      }
     },
     "This study will request read-access to collect the following Health samples:" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este estudio solicitará acceso de lectura para recopilar las siguientes muestras de Salud:\n"
+          }
+        }
+      }
     },
     "Time Asleep" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo Dormido\n"
+          }
+        }
+      }
     },
     "Time Elapsed" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo Transcurrido\n"
+          }
+        }
+      }
     },
     "Time Info" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Información del Tiempo\n"
+          }
+        }
+      }
     },
     "Time Remaining" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo Restante\n"
+          }
+        }
+      }
     },
     "Time Zone" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zona Horaria\n"
+          }
+        }
+      }
     },
     "Timed Walking Test" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prueba de Caminata Cronometrada\n"
+          }
+        }
+      }
     },
     "Timed Walking/Running Tests" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pruebas de Caminata/Corrida Cronometradas\n"
+          }
+        }
+      }
     },
     "TIMED_WALK_TEST_EXPLAINER_6_MIN_WALK" : {
       "localizations" : {
@@ -2339,7 +4379,14 @@
 
     },
     "Total Household Income" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingreso Total del Hogar\n"
+          }
+        }
+      }
     },
     "True" : {
       "localizations" : {
@@ -2441,16 +4488,44 @@
       }
     },
     "Unable to find Questionnaire" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo encontrar el Cuestionario\n"
+          }
+        }
+      }
     },
     "Unable to load data" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo cargar los datos\n"
+          }
+        }
+      }
     },
     "Unenroll" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Darse de baja\n"
+          }
+        }
+      }
     },
     "unit" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "unidad"
+          }
+        }
+      }
     },
     "Upcoming Tasks" : {
       "localizations" : {
@@ -2463,43 +4538,127 @@
       }
     },
     "Uploading Health Data" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando Datos de Salud\n"
+          }
+        }
+      }
     },
     "US State / Region" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado / Región de EE. UU.\n"
+          }
+        }
+      }
     },
     "US State / Territory" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado / Territorio de EE. UU.\n"
+          }
+        }
+      }
     },
     "Use this option to auto-fill Blood Type, Height, Weight, Date of Birth, and Biological Sex, by reading each from the Health app, if available.\nAlternatively, you can also tap the respective fields below to manually enter a value, or to override the value read from the Health app." : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliza esta opción para autocompletar el Tipo de Sangre, Altura, Peso, Fecha de Nacimiento y Sexo Biológico, leyendo cada uno desde la aplicación de Salud, si está disponible. Alternativamente, también puedes tocar los campos respectivos a continuación para ingresar un valor manualmente, o para sobrescribir el valor leído de la aplicación de Salud.\n"
+          }
+        }
+      }
     },
     "Utah" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utah"
+          }
+        }
+      }
     },
     "Vermont" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vermont"
+          }
+        }
+      }
     },
     "version" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "versión"
+          }
+        }
+      }
     },
     "Virgin Islands" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Islas Vírgenes\n"
+          }
+        }
+      }
     },
     "Virginia" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Virginia"
+          }
+        }
+      }
     },
     "walk" : {
 
     },
     "Warning Sign" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Señal de Advertencia\n"
+          }
+        }
+      }
     },
     "Washington" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Washington "
+          }
+        }
+      }
     },
     "Weight" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peso"
+          }
+        }
+      }
     },
     "Welcome to My Heart Counts" : {
       "localizations" : {
@@ -2528,7 +4687,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tu participación ayuda a los investigadores de Stanford a comprender cómo el entrenamiento digital personalizado puede mejorar la actividad física y tu salud hoy y en el futuro."
+            "value" : "Su participación ayuda a los investigadores de Stanford a comprender cómo el entrenamiento digital personalizado puede mejorar la actividad física y su salud general hoy y en el futuro."
           }
         }
       }
@@ -2550,7 +4709,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Contribuye a la Investigación de la Salud del Corazón"
+            "value" : "Contribuya a la Investigación de la Salud del Corazón"
           }
         }
       }
@@ -2572,7 +4731,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Experimenta la versión nueva de una de las aplicaciones basada en estudios de investigación más grande jamás realizada."
+            "value" : "Experimente la versión rediseñada de una de las aplicaciones de estudios de investigación más grandes jamás realizadas."
           }
         }
       }
@@ -2616,7 +4775,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Participa completamente en línea, compartiendo de manera segura tus datos de actividad directamente desde su iPhone y Apple Watch."
+            "value" : "Participe completamente en línea, compartiendo de manera segura sus datos de actividad directamente desde su iPhone y Apple Watch."
           }
         }
       }
@@ -2659,39 +4818,74 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bienvenido/a al Estudio de Salud Cardiovascular My Heart Counts"
+            "state" : "translated",
+            "value" : "Bienvenido al Estudio de Salud Cardiovascular My Heart Counts"
           }
         }
       }
     },
     "West Virginia" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Virginia Occidental\n"
+          }
+        }
+      }
     },
     "What country do you currently live in?" : {
       "localizations" : {
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿En qué país vives actualmente?"
+            "value" : "¿En qué país vive actualmente?"
           }
         }
       }
     },
     "Wisconsin" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wisconsin"
+          }
+        }
+      }
     },
     "Within last year, or am using NDS" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En el último año, o estoy usando NDS\n"
+          }
+        }
+      }
     },
     "World" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mundo"
+          }
+        }
+      }
     },
     "wristLocation" : {
 
     },
     "Wyoming" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyoming"
+          }
+        }
+      }
     },
     "Yes" : {
       "localizations" : {
@@ -2704,28 +4898,77 @@
       }
     },
     "Yes, Caribbean Hispanic, including Cuban and Puerto Rican" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sí, Hispano del Caribe, incluyendo Cubano y Puertorriqueño\n"
+          }
+        }
+      }
     },
     "Yes, European Hispanic, including Spanish and Portuguese, Hispanic, Latina" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sí, Hispano Europeo, incluyendo Español y Portugués, Hispano, Latina\n"
+          }
+        }
+      }
     },
     "Yes, Mexican, Mexican American, or Chicano" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sí, Mexicano, Mexicano Americano, o Chicano\n"
+          }
+        }
+      }
     },
     "Yes, other Hispanic, Latino" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sí, otro Hispano, Latino\n"
+          }
+        }
+      }
     },
     "Yes, South American Hispanic" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sí, Hispano Sudamericano\n"
+          }
+        }
+      }
     },
     "Yesterday" : {
 
     },
     "You can select multiple options" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puedes seleccionar múltiples opciones\n"
+          }
+        }
+      }
     },
     "You're All Set" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Estás listo!\n"
+          }
+        }
+      }
     },
     "Your Account" : {
       "localizations" : {
@@ -2738,7 +4981,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Su Cuenta"
+            "value" : "Tu Cuenta\n"
           }
         }
       }

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -129,6 +129,12 @@
             "value" : "Please log in to your existing account. If you do not have an existing account, please sign up."
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please log in to your existing account. If you do not have an existing account, please sign up."
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -140,6 +146,12 @@
     "ACCOUNT_SETUP_DESCRIPTION_SUBTITLE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you were part of the original My Heart Counts study, your account will not transfer over and you will need to create a new account."
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "If you were part of the original My Heart Counts study, your account will not transfer over and you will need to create a new account."
@@ -160,16 +172,11 @@
             "state" : "translated",
             "value" : "You are already logged in with the account shown below. Continue or change your account by logging out."
           }
-        }
-      }
-    },
-    "ACCOUNT_SUBTITLE" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The My Heart Counts iOS application demonstrates the usage of the Firebase Account Module."
+            "value" : "You are already logged in with the account shown below. Continue or change your account by logging out."
           }
         }
       }
@@ -331,12 +338,24 @@
             "state" : "translated",
             "value" : "Adult Congenital Heart Disease"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adult Congenital Heart Disease"
+          }
         }
       }
     },
     "COMORBIDITY_CAD" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coronary Artery Disease"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Coronary Artery Disease"
@@ -351,12 +370,24 @@
             "state" : "translated",
             "value" : "Diabetes"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diabetes"
+          }
         }
       }
     },
     "COMORBIDITY_HEART_FAILURE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heart Failure"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Heart Failure"
@@ -371,12 +402,24 @@
             "state" : "translated",
             "value" : "None"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "None"
+          }
         }
       }
     },
     "COMORBIDITY_PAH" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulmonary Arterial Hypertension"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pulmonary Arterial Hypertension"
@@ -398,6 +441,12 @@
             "value" : "If at any point during this study I do not feel well, I should immediately contact my healthcare provider."
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If at any point during this study I do not feel well, I should immediately contact my healthcare provider."
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -409,6 +458,12 @@
     "COMPREHENSION_QUESTION_2" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I am not required to complete all or any parts of this study if I don’t want to."
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "I am not required to complete all or any parts of this study if I don’t want to."
@@ -430,6 +485,12 @@
             "value" : "Once I start participating in this study, I can choose to not continue at any time with no repercussions to me."
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Once I start participating in this study, I can choose to not continue at any time with no repercussions to me."
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -446,6 +507,12 @@
             "value" : "Please answer a few review questions to ensure you understand the consent form"
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please answer a few review questions to ensure you understand the consent form"
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -457,6 +524,12 @@
     "COMPREHENSION_STEP_TITLE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprehension of Consent Questionnaire"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comprehension of Consent Questionnaire"
@@ -490,17 +563,6 @@
     },
     "Consent Version" : {
 
-    },
-    "CONSENT_LOADING_ERROR" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please include a markdown based document named \"ConsentDocument\" in your module Bundle."
-          }
-        }
-      }
     },
     "Continue" : {
 
@@ -580,6 +642,12 @@
             "value" : "Before you begin, we’ll ask you a few quick questions to ensure the study is a good fit for you."
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Before you begin, we’ll ask you a few quick questions to ensure the study is a good fit for you."
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -591,6 +659,12 @@
     "ELIGIBILITY_STEP_TITLE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eligibility"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Eligibility"
@@ -663,6 +737,12 @@
             "state" : "translated",
             "value" : "Your feedback helps us improve My Heart Counts and [TODO some text about better helping more people???]\n\nThe feedback you share with us will be associated with your Email address.\nThis allows us to reach out to you if required."
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your feedback helps us improve My Heart Counts and [TODO some text about better helping more people???]\n\nThe feedback you share with us will be associated with your Email address.\nThis allows us to reach out to you if required."
+          }
         }
       }
     },
@@ -692,6 +772,12 @@
             "value" : "What happens next:\n- Baseline Monitoring Week: Over the next 7 days, you'll be guided through several short activities:\n    - Completing surveys about your health, lifestyle, and well-being\n    - Recording your baseline physical activity through the app\n    - Performing optional fitness assessments if appropriate for your health status\n- Daily Tasks: Each day, you'll see a personalized list of tasks in your dashboard. These typically take just 5-10 minutes to complete.\n- Data Collection: The app will begin collecting activity data from your phone and any connected wearable devices you've authorized."
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What happens next:\n- Baseline Monitoring Week: Over the next 7 days, you'll be guided through several short activities:\n    - Completing surveys about your health, lifestyle, and well-being\n    - Recording your baseline physical activity through the app\n    - Performing optional fitness assessments if appropriate for your health status\n- Daily Tasks: Each day, you'll see a personalized list of tasks in your dashboard. These typically take just 5-10 minutes to complete.\n- Data Collection: The app will begin collecting activity data from your phone and any connected wearable devices you've authorized."
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -708,6 +794,12 @@
             "value" : "By joining this study, you're contributing to important research that may help improve our understanding of heart health for people across diverse communities."
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "By joining this study, you're contributing to important research that may help improve our understanding of heart health for people across diverse communities."
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -719,6 +811,12 @@
     "FINAL_ENROLLMENT_STEP_MESSAGE_TRIAL_SECTION" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "After your baseline week, you'll begin the 2-week trial comparing different types of physical activity coaching. You'll receive notifications when this phase begins."
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "After your baseline week, you'll begin the 2-week trial comparing different types of physical activity coaching. You'll receive notifications when this phase begins."
@@ -754,12 +852,24 @@
             "state" : "translated",
             "value" : "Female"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Female"
+          }
         }
       }
     },
     "GENDER_MALE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Male"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Male"
@@ -774,12 +884,24 @@
             "state" : "translated",
             "value" : "Gender Variant / Non-Conforming"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gender Variant / Non-Conforming"
+          }
         }
       }
     },
     "GENDER_PREFER_NOT_TO_STATE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefer not to state"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prefer not to state"
@@ -794,12 +916,24 @@
             "state" : "translated",
             "value" : "Transgender Female"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transgender Female"
+          }
         }
       }
     },
     "GENDER_TRANS_MALE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transgender Male"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Transgender Male"
@@ -855,12 +989,24 @@
             "state" : "translated",
             "value" : "My Heart Counts needs read-access to automatically collect data such as heart rate, step counts, active calories, sleep durations, etc.\n\nYour data will not be shared with anyone outside of the My Heart Counts Research Team unless you have selected to allow broader data sharing. Prior to sharing data outside of the My Heart Counts Research Team, researchers will need to denominated they are qualified to persome research that will review. Broadly shared data will have all information de-identified and not traceable to you.\n\nMoreover, the data will only be shared with qualified researchers who must submit applications to access de-identified data.\n\nYou can revoke this access at any time.\n"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "My Heart Counts needs read-access to automatically collect data such as heart rate, step counts, active calories, sleep durations, etc.\n\nYour data will not be shared with anyone outside of the My Heart Counts Research Team unless you have selected to allow broader data sharing. Prior to sharing data outside of the My Heart Counts Research Team, researchers will need to denominated they are qualified to persome research that will review. Broadly shared data will have all information de-identified and not traceable to you.\n\nMoreover, the data will only be shared with qualified researchers who must submit applications to access de-identified data.\n\nYou can revoke this access at any time.\n"
+          }
         }
       }
     },
     "HEALTHKIT_PERMISSIONS_SUBTITLE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The My Heart Counts Study uses Health Data collected on your iPhone to further our research goals. Granting access to all fields (or as many as you are comfortable with) ensures the most well powered study possible."
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "The My Heart Counts Study uses Health Data collected on your iPhone to further our research goals. Granting access to all fields (or as many as you are comfortable with) ensures the most well powered study possible."
@@ -895,6 +1041,12 @@
             "value" : "Your personalized score reflects your overall health based on the factors listed below. Track it over time to see how lifestyle changes impact your heart health."
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your personalized score reflects your overall health based on the factors listed below. Track it over time to see how lifestyle changes impact your heart health."
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -911,21 +1063,16 @@
             "value" : "## Understanding Your My Heart Counts Health Score\n\n### What is this score?\nYour My Heart Counts Health Score provides a snapshot of your overall cardiovascular health based on the information you've shared with us. This score combines multiple factors that research has shown to be important for cardiovascular health.\n\n### How is it calculated?\nYour score incorporates:\n- Physical activity levels from your daily movement patterns\n- Heart health risk factors you reported in surveys (like blood pressure, cholesterol, if you know these)\n- Lifestyle factors such as diet, sleep, and overall mental health\n- Health behaviors like smoking status\n\n### What to do with this information:\n- **Track changes** over time to see how your heart health evolves. Understand that higher scores mean better overall health. By tracking your changes over time you can try and improve your overall health!\n- **Identify specific areas** where small changes might have the biggest impact.\n- **Set personal goals** based on which components have the most room for improvement. \n\nImportant note: This score is provided for research and educational purposes only. It is not a medical diagnosis and should not replace consultation with healthcare providers. The My Heart Counts Health Score is designed to encourage positive health behaviors and support your heart health journey."
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## Understanding Your My Heart Counts Health Score\n\n### What is this score?\nYour My Heart Counts Health Score provides a snapshot of your overall cardiovascular health based on the information you've shared with us. This score combines multiple factors that research has shown to be important for cardiovascular health.\n\n### How is it calculated?\nYour score incorporates:\n- Physical activity levels from your daily movement patterns\n- Heart health risk factors you reported in surveys (like blood pressure, cholesterol, if you know these)\n- Lifestyle factors such as diet, sleep, and overall mental health\n- Health behaviors like smoking status\n\n### What to do with this information:\n- **Track changes** over time to see how your heart health evolves. Understand that higher scores mean better overall health. By tracking your changes over time you can try and improve your overall health!\n- **Identify specific areas** where small changes might have the biggest impact.\n- **Set personal goals** based on which components have the most room for improvement. \n\nImportant note: This score is provided for research and educational purposes only. It is not a medical diagnosis and should not replace consultation with healthcare providers. The My Heart Counts Health Score is designed to encourage positive health behaviors and support your heart health journey."
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "## Entienda su Puntuación de Salud de My Heart Counts\n\n### ¿Qué es esta puntuación?\nSu Puntuación de Salud de My Heart Counts proporciona una instantánea de su salud cardiovascular general basada en la información que ha compartido con nosotros. Esta puntuación combina varios factores que la investigación ha demostrado que son importantes para la salud cardiovascular.\n\n### ¿Cómo se calcula?\nSu puntuación incorpora:\n- Niveles de actividad física de sus patrones de movimiento diarios\n- Factores de riesgo para la salud del corazón que reportó en las encuestas (como presión arterial, colesterol - si los conoce)\n- Factores de estilo de vida como la dieta, el sueño y la salud mental en general\n- Comportamientos de salud como el estado de fumador\n\n### Qué hacer con esta información:\n- Rastree los cambios a lo largo del tiempo para ver cómo evoluciona la salud de su corazón. Entienda que puntuaciones más altas significan mejor salud en general. Al rastrear sus cambios a lo largo del tiempo, ¡puede intentar mejorar su salud general!\n- Identifique áreas específicas donde pequeños cambios puedan tener el mayor impacto.\n- Establezca metas personales basadas en qué componentes tienen más margen de mejora.\n\nNota importante: Esta puntuación se proporciona sólo con fines de investigación y educativos. No es un diagnóstico médico y no debe reemplazar la consulta con proveedores de atención médica. La Puntuación de Salud de My Heart Counts está diseñada para fomentar comportamientos de salud positivos y apoyar su viaje hacia la salud del corazón.\n\n\n\n"
-          }
-        }
-      }
-    },
-    "HEART_HEALTH_DASHBOARD_METRIC_EXPLAINER_DIET_SCORE" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "–––\nlink: https://www.who.int/news-room/fact-sheets/detail/healthy-diet\n–––\nThis dietary questionnaire, developed by the British Heart Foundation, helps you assess your eating habits and identify areas for improvement. A healthy diet—rich in fruits, vegetables, whole grains, lean proteins, and healthy fats—supports heart health, energy, and chronic disease prevention (such as cancer and dementia). Limiting added sugars, salt, and processed foods is also important. However, diet is complex and influenced by culture, preferences, and access to foods, making it hard to assess accurately with simple surveys. While general guidelines help, personalized nutrition advice with your healthcare provider or licensed dietician is best for lasting health benefits.\n\nIf your score indicates room for improvement, consider gradually adopting healthier dietary habits to enhance your overall well-being and reduce your long-term risk of cardiovascular disease, cancer, and dementia.\n\n\n\n\n"
           }
         }
       }
@@ -1050,17 +1197,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Learn More"
-          }
-        }
-      }
-    },
-    "Learn more about My Heart Counts" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtenga más información sobre My Heart Counts."
           }
         }
       }
@@ -1267,6 +1403,12 @@
             "value" : "Please allow My Heart Counts to send you notifications so that we can properly carry out research.\n\nWe will do our best to keep the notifications to a minimum."
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please allow My Heart Counts to send you notifications so that we can properly carry out research.\n\nWe will do our best to keep the notifications to a minimum."
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1313,6 +1455,12 @@
             "state" : "translated",
             "value" : "This research study is conducted by Stanford University School of Medicine researchers to understand how physical activity relates to cardiovascular health. The app will guide you through various assessments including the 6-minute walk test. Your participation is flexible meaning you can engage with the study as much or as little as you choose. The smartphone-based approach allows us to collect data in your natural environment rather than requiring visits to a clinical facility."
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "This research study is conducted by Stanford University School of Medicine researchers to understand how physical activity relates to cardiovascular health. The app will guide you through various assessments including the 6-minute walk test. Your participation is flexible meaning you can engage with the study as much or as little as you choose. The smartphone-based approach allows us to collect data in your natural environment rather than requiring visits to a clinical facility."
+          }
         }
       }
     },
@@ -1357,6 +1505,12 @@
     "ONBOARDING_DISCLAIMER_2_LEARN_MORE_TEXT" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The optional trial uses a \"randomized crossover\" design where you'll experience both types of coaching interventions - personalized activity prompts and standard activity prompts - for 7 days each (total of 14 days). This will begin after the baseline monitoring week. The order in which you receive these interventions will be randomly assigned, similar to flipping a coin. This design allows researchers to compare how the different coaching approaches affect your activity levels while controlling for individual differences, as each participant serves as their own control. You can choose not to participate in this trial component and still be part of the main My Heart Counts study."
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "The optional trial uses a \"randomized crossover\" design where you'll experience both types of coaching interventions - personalized activity prompts and standard activity prompts - for 7 days each (total of 14 days). This will begin after the baseline monitoring week. The order in which you receive these interventions will be randomly assigned, similar to flipping a coin. This design allows researchers to compare how the different coaching approaches affect your activity levels while controlling for individual differences, as each participant serves as their own control. You can choose not to participate in this trial component and still be part of the main My Heart Counts study."
@@ -1409,6 +1563,12 @@
             "state" : "translated",
             "value" : "The study collects data through your phone's sensors, including accelerometer data for movement, GPS for location during specific fitness tests, and heart rate if available through connected devices. All data transmission uses encryption technology to protect your information. We separate your identifying information from your health data in our secure databases. You'll have options within the app to control what information is shared We follow strict protocols approved by Stanford's Institutional Review Board to maintain your privacy."
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The study collects data through your phone's sensors, including accelerometer data for movement, GPS for location during specific fitness tests, and heart rate if available through connected devices. All data transmission uses encryption technology to protect your information. We separate your identifying information from your health data in our secure databases. You'll have options within the app to control what information is shared We follow strict protocols approved by Stanford's Institutional Review Board to maintain your privacy."
+          }
         }
       }
     },
@@ -1442,6 +1602,12 @@
             "value" : "Data Collection & Privacy"
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Collection & Privacy"
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1457,12 +1623,24 @@
             "state" : "translated",
             "value" : "Physical risks are minimal but could include temporary muscle soreness or strain from fitness activities. There's also a small risk related to data privacy despite our security measures. Benefits include access to your own activity data and the knowledge that you're contributing to research that may help improve heart health recommendations. Your participation is entirely voluntary, and you can stop participating at any time without penalty by contacting the research team. This research has been reviewed by Stanford's Institutional Review Board to ensure participant protection."
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Physical risks are minimal but could include temporary muscle soreness or strain from fitness activities. There's also a small risk related to data privacy despite our security measures. Benefits include access to your own activity data and the knowledge that you're contributing to research that may help improve heart health recommendations. Your participation is entirely voluntary, and you can stop participating at any time without penalty by contacting the research team. This research has been reviewed by Stanford's Institutional Review Board to ensure participant protection."
+          }
         }
       }
     },
     "ONBOARDING_DISCLAIMER_4_PRIMARY_TEXT" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Participation is completely voluntary with minimal risks. Benefits include gaining insights about your heart health and contributing to cardiovascular research. You can withdraw from the study at anytime."
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Participation is completely voluntary with minimal risks. Benefits include gaining insights about your heart health and contributing to cardiovascular research. You can withdraw from the study at anytime."
@@ -1479,6 +1657,12 @@
     "ONBOARDING_DISCLAIMER_4_TITLE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Risks, Benefits & Your Rights"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Risks, Benefits & Your Rights"
@@ -1529,6 +1713,12 @@
             "state" : "translated",
             "value" : "Past Timed Walk/Run Test Results"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Past Timed Walk/Run Test Results"
+          }
         }
       }
     },
@@ -1566,12 +1756,24 @@
             "state" : "translated",
             "value" : "African American"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "African American"
+          }
         }
       }
     },
     "RACE_ALASKA_NATIVE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alaska Native"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alaska Native"
@@ -1586,16 +1788,11 @@
             "state" : "translated",
             "value" : "American Indian"
           }
-        }
-      }
-    },
-    "RACE_ASIAN" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Asian"
+            "value" : "American Indian"
           }
         }
       }
@@ -1607,16 +1804,11 @@
             "state" : "translated",
             "value" : "Asian Indian"
           }
-        }
-      }
-    },
-    "RACE_CAUCASIAN" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Caucasian"
+            "value" : "Asian Indian"
           }
         }
       }
@@ -1624,6 +1816,12 @@
     "RACE_CHINESE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chinese"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chinese"
@@ -1638,16 +1836,11 @@
             "state" : "translated",
             "value" : "Filipino"
           }
-        }
-      }
-    },
-    "RACE_HISPANIC_LATINO" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hispanic / Latino"
+            "value" : "Filipino"
           }
         }
       }
@@ -1655,6 +1848,12 @@
     "RACE_JAPANESE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japanese"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Japanese"
@@ -1669,27 +1868,11 @@
             "state" : "translated",
             "value" : "Korean"
           }
-        }
-      }
-    },
-    "RACE_MENA" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Middle East and Northern Africa"
-          }
-        }
-      }
-    },
-    "RACE_NATIVE_HAWAIIAN" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Native Hawaiian"
+            "value" : "Korean"
           }
         }
       }
@@ -1697,6 +1880,12 @@
     "RACE_NO_SELECTION" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Selection"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "No Selection"
@@ -1711,12 +1900,24 @@
             "state" : "translated",
             "value" : "Other"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Other"
+          }
         }
       }
     },
     "RACE_PACIFIC_ISLANDER" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pacific Islander"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pacific Islander"
@@ -1731,12 +1932,24 @@
             "state" : "translated",
             "value" : "Prefer not to Answer"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefer not to Answer"
+          }
         }
       }
     },
     "RACE_SELECTOR_LIST_FOOTER" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can select multiple options."
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "You can select multiple options."
@@ -1751,12 +1964,24 @@
             "state" : "translated",
             "value" : "Vietnamese"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vietnamese"
+          }
         }
       }
     },
     "RACE_WHITE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "White"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "White"
@@ -1818,28 +2043,6 @@
     "Score Result" : {
 
     },
-    "SCREENING_STEP_SUBTITLE" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Before you begin, we'll ask you a few quick questions to confirm you're eligible to participate in this study. This helps us ensure the study is a good fit for you"
-          }
-        }
-      }
-    },
-    "SCREENING_STEP_TITLE" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eligibility"
-          }
-        }
-      }
-    },
     "Select a Region" : {
 
     },
@@ -1877,12 +2080,24 @@
             "state" : "translated",
             "value" : "Female"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Female"
+          }
         }
       }
     },
     "SEX_INTERSEX" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intersex"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Intersex"
@@ -1897,12 +2112,24 @@
             "state" : "translated",
             "value" : "Male"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Male"
+          }
         }
       }
     },
     "SEX_PREFER_NOT_TO_STATE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefer not to state"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prefer not to state"
@@ -1918,28 +2145,6 @@
     },
     "South Dakota" : {
 
-    },
-    "Spezi Modules" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spezi Modules"
-          }
-        }
-      }
-    },
-    "Spezi Scheduler Notifications." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spezi Scheduler Notifications."
-          }
-        }
-      }
     },
     "Start All" : {
 
@@ -1963,21 +2168,17 @@
 
     },
     "Summarized" : {
-
-    },
-    "Supplemental Categories" : {
-
-    },
-    "Swift Package Manager" : {
-      "extractionState" : "stale",
       "localizations" : {
-        "en" : {
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swift Package Manager"
+            "value" : "Summarised"
           }
         }
       }
+    },
+    "Supplemental Categories" : {
+
     },
     "Take Test" : {
 
@@ -2002,17 +2203,6 @@
     },
     "The app was unable to load the study, but we're not sure why" : {
 
-    },
-    "The Spezi Framework" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The Spezi Framework"
-          }
-        }
-      }
     },
     "The Timed Walking Test requires read access to Motion and Fitness Data." : {
 
@@ -2039,6 +2229,9 @@
 
     },
     "Timed Walking/Running Tests" : {
+
+    },
+    "Today" : {
 
     },
     "TODO: make this look pretty!" : {
@@ -2070,19 +2263,84 @@
 
     },
     "UK_REGION_ENGLAND" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "England"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "England"
+          }
+        }
+      }
     },
     "UK_REGION_NORTHERN_IRELAND" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Northern Ireland"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Northern Ireland"
+          }
+        }
+      }
     },
     "UK_REGION_NOT_SET" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Set"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Set"
+          }
+        }
+      }
     },
     "UK_REGION_SCOTLAND" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scotland"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scotland"
+          }
+        }
+      }
     },
     "UK_REGION_WALES" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wales"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wales"
+          }
+        }
+      }
     },
     "Unable to find Questionnaire" : {
 
@@ -2182,6 +2440,12 @@
             "value" : "Contribute to Heart Health Research"
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contribute to Heart Health Research"
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2215,6 +2479,12 @@
     "WELCOME_AREA2_TITLE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A Redesigned App to Support You"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A Redesigned App to Support You"
@@ -2258,6 +2528,12 @@
             "value" : "Easy and Secure Participation"
           }
         },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easy and Secure Participation"
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2269,6 +2545,12 @@
     "WELCOME_SUBTITLE" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welcome to the My Heart Counts\nCardiovascular Health Study"
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Welcome to the My Heart Counts\nCardiovascular Health Study"
@@ -2333,6 +2615,9 @@
 
     },
     "Yes, South American Hispanic" : {
+
+    },
+    "Yesterday" : {
 
     },
     "You can select multiple options" : {

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -29,6 +29,19 @@
     "%@ bpm" : {
 
     },
+    "%@-Minute Run Test" : {
+
+    },
+    "%@-Minute Walk Test" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@-Minute Walk Test"
+          }
+        }
+      }
+    },
     "%lld ft" : {
 
     },
@@ -115,6 +128,9 @@
     "1 to 5 years ago" : {
 
     },
+    "12-Minute Run Test (Cooper Test)" : {
+
+    },
     "100" : {
 
     },
@@ -138,7 +154,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Por favor, inicie sesión en su cuenta existente. Si no tiene una cuenta existente, por favor regístrese."
+            "value" : "Por favor, inicia sesión con tu cuenta. Si aún no tienes una cuenta, regístrateate."
           }
         }
       }
@@ -160,7 +176,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Si formó parte del estudio original de My Heart Counts, su cuenta no se transferirá y necesitará crear una nueva cuenta."
+            "value" : "Si formasteaste parte del estudio original de My Heart Counts, tu cuenta no se transferirá y necesitarás crear una nueva cuenta."
           }
         }
       }
@@ -238,7 +254,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Tiene %lld años o más?"
+            "value" : "¿Tienes %lld años o más?"
           }
         }
       }
@@ -257,16 +273,6 @@
     },
     "Arkansas" : {
 
-    },
-    "As part of the %@, we'll collect some mobility information from your iPhone and Apple Watch, such as Step Count, Distance, and Heart Rate, while you go on a short walk for %@ minute%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "As part of the %1$@, we'll collect some mobility information from your iPhone and Apple Watch, such as Step Count, Distance, and Heart Rate, while you go on a short walk for %2$@ minute%3$@"
-          }
-        }
-      }
     },
     "AuthorizationStatus" : {
 
@@ -301,7 +307,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Puede leer y entender %@ para proporcionar su consentimiento informado y seguir las instrucciones?"
+            "value" : "¿Puedes leer y entender %@ para proporcionar tu consentimiento informado y seguir las instrucciones?\n"
           }
         }
       }
@@ -472,7 +478,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No estoy obligado a completar todas o ninguna de las partes de este estudio si no quiero."
+            "value" : "No estoy obligado/a a completar todas o ninguna de las partes de este estudio si no quiero."
           }
         }
       }
@@ -516,7 +522,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Por favor, responda algunas preguntas de repaso para asegurarse de que entiende el formulario de consentimiento."
+            "value" : "Por favor, responde algunas preguntas de repaso para asegurarnos de que entiende el formulario de consentimiento."
           }
         }
       }
@@ -628,6 +634,51 @@
     "Done" : {
 
     },
+    "ECG_INSTRUCTIONS_TEXT" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## Taking an ECG with Your Apple Watch\n\nYour Apple Watch can record an electrocardiogram (ECG) to check your heart rhythm. This feature helps you capture your heart's electrical activity in just 30 seconds.\n\nTo take an ECG, make sure your watch is snug on your wrist. Open the ECG app on your Apple Watch and rest your arms on a table or in your lap. Place your finger on the Digital Crown without pressing it, and hold still for 30 seconds while the recording completes.\n\nThe app will classify your heart rhythm as Sinus Rhythm, Atrial Fibrillation, Low/High Heart Rate, or Inconclusive. Your results are saved in the Health app on your iPhone for you to review or share with your doctor.\n\nRemember: This feature is not constantly monitoring for AFib and cannot detect heart attacks. If you experience chest pain, pressure, or other symptoms, call emergency services immediately."
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "## Taking an ECG with Your Apple Watch\n\nYour Apple Watch can record an electrocardiogram (ECG) to check your heart rhythm. This feature helps you capture your heart's electrical activity in just 30 seconds.\n\nTo take an ECG, make sure your watch is snug on your wrist. Open the ECG app on your Apple Watch and rest your arms on a table or in your lap. Place your finger on the Digital Crown without pressing it, and hold still for 30 seconds while the recording completes.\n\nThe app will classify your heart rhythm as Sinus Rhythm, Atrial Fibrillation, Low/High Heart Rate, or Inconclusive. Your results are saved in the Health app on your iPhone for you to review or share with your doctor.\n\nRemember: This feature is not constantly monitoring for AFib and cannot detect heart attacks. If you experience chest pain, pressure, or other symptoms, call emergency services immediately."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## Realizar un ECG con su Apple Watch\n\nTu Apple Watch puede registrar un electrocardiograma (ECG) para verificar el ritmo de tu corazón. Esta función te ayuda a capturar la actividad eléctrica de tu corazón en solo 30 segundos.\n\nPara realizar un ECG, asegúrete de que tu reloj esté bien ajustado en tu muñeca. Abre la aplicación ECG en tu Apple Watch y descansa los brazos sobre una mesa o en tu regazo. Coloca tu dedo en la Corona Digital sin presionarla, y mantéte inmóvil durante 30 segundos mientras se completa la captura.\n\nLa aplicación clasificará tu ritmo cardíaco como Ritmo Sinusal, Fibrilación Auricular, Frecuencia Cardíaca Baja/Alta o Inconcluso. Los resultados se guardan en la aplicación Salud en su iPhone para que los revises o compartas con tu médico.\n\nRecuerde: Esta función no monitorea continuamente la Fibrilación Auricular y no puede detectar ataques cardíacos. Si experimenta dolor en el pecho, presión u otros síntomas, llame a los servicios de emergencia inmediatamente."
+          }
+        }
+      }
+    },
+    "ECG_INSTRUCTIONS_TITLE" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taking an ECG with Your Apple Watch"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taking an ECG with Your Apple Watch"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Realizar un ECG con su Apple Watch"
+          }
+        }
+      }
+    },
     "Educational Level" : {
 
     },
@@ -645,13 +696,13 @@
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Before you begin, we’ll ask you a few quick questions to ensure the study is a good fit for you."
+            "value" : "Before you begin, we'll ask you a few quick questions to ensure the study is a good fit for you."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Antes de comenzar, le haremos unas preguntas rápidas para asegurarnos de que el estudio sea adecuado para usted."
+            "value" : "Antes de comenzar, te haremos unas preguntas rápidas para asegurarnos que el estudio sea adecuado para ti."
           }
         }
       }
@@ -769,19 +820,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "What happens next:\n- Baseline Monitoring Week: Over the next 7 days, you'll be guided through several short activities:\n    - Completing surveys about your health, lifestyle, and well-being\n    - Recording your baseline physical activity through the app\n    - Performing optional fitness assessments if appropriate for your health status\n- Daily Tasks: Each day, you'll see a personalized list of tasks in your dashboard. These typically take just 5-10 minutes to complete.\n- Data Collection: The app will begin collecting activity data from your phone and any connected wearable devices you've authorized."
+            "value" : "What happens next:\n- Baseline Monitoring Week: Over the next 7 days, you’ll be guided through several short activities:\n    - Completing surveys about your health, lifestyle, and well-being\n    - Recording your baseline physical activity through the app\n    - Performing optimal fitness assessments if appropriate for your health status\n- Daily Tasks: Each day, you’ll see a personalized list of tasks in your dashboard. These typically take just 5-10 minutes to complete.\n- Data Collection: The app will begin collecting activity data from your phone and any connected wearable devices you’ve authorized."
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "What happens next:\n- Baseline Monitoring Week: Over the next 7 days, you'll be guided through several short activities:\n    - Completing surveys about your health, lifestyle, and well-being\n    - Recording your baseline physical activity through the app\n    - Performing optional fitness assessments if appropriate for your health status\n- Daily Tasks: Each day, you'll see a personalized list of tasks in your dashboard. These typically take just 5-10 minutes to complete.\n- Data Collection: The app will begin collecting activity data from your phone and any connected wearable devices you've authorized."
+            "value" : "What happens next:\n- Baseline Monitoring Week: Over the next 7 days, you’ll be guided through several short activities:\n    - Completing surveys about your health, lifestyle, and well-being\n    - Recording your baseline physical activity through the app\n    - Performing optimal fitness assessments if appropriate for your health status\n- Daily Tasks: Each day, you’ll see a personalized list of tasks in your dashboard. These typically take just 5-10 minutes to complete.\n- Data Collection: The app will begin collecting activity data from your phone and any connected wearable devices you’ve authorized.\n"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Qué sucede a continuación?:\n- Semana de Monitoreo Inicial: Durante los próximos 7 días, será guiado a través de varias actividades cortas:\n    - Completar encuestas sobre su salud, estilo de vida y bienestar\n    - Registrar su actividad física inicial a través de la aplicación\n    - Realizar evaluaciones de condición física óptima si es adecuado para su estado de salud\n- Tareas Diarias: Cada día, verá una lista personalizada de tareas en su tablero. Normalmente toman solo 5-10 minutos para completar.\n- Recolección de Datos: La aplicación comenzará a recopilar datos de actividad de su teléfono y cualquier dispositivo portátil conectado que haya autorizado."
+            "value" : "¿Qué sucede a continuación?:\n- Semana de Monitoreo Inicial: Durante los próximos 7 días, serás guiado/a a través de varias actividades cortas:\n    - Completar encuestas sobre tu salud, estilo de vida y bienestar\n    - Registrar tu actividad física inicial a través de la aplicación\n    - Realizar evaluaciones de condición física óptima si es adecuada para su estado de salud\n- Tareas Diarias: Cada día, verá una lista personalizada de tareas en su tablero. Normalmente toman solo 5-10 minutos en completarse.\n- Recolección de Datos: La aplicación comenzará a recopilar datos de actividad de tu teléfono y cualquier dispositivo portátil conectado que hayas autorizado."
           }
         }
       }
@@ -791,19 +842,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "By joining this study, you're contributing to important research that may help improve our understanding of heart health for people across diverse communities."
+            "value" : "By joining this study, you’re contributing to important research that may help improve our understanding of heart health for people across diverse communities."
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "By joining this study, you're contributing to important research that may help improve our understanding of heart health for people across diverse communities."
+            "value" : "By joining this study, you’re contributing to important research that may help improve our understanding of heart health for people across diverse communities."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Al unirse a este estudio, está contribuyendo a una investigación importante que puede ayudar a mejorar nuestra comprensión de la salud del corazón en personas de diversas comunidades"
+            "value" : "Al unirte a este estudio, estás contribuyendo a una investigación importante que puede ayudar a mejorar nuestra comprensión de la salud del corazón en personas de diversas comunidades."
           }
         }
       }
@@ -987,13 +1038,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "My Heart Counts needs read-access to automatically collect data such as heart rate, step counts, active calories, sleep durations, etc.\n\nYour data will not be shared with anyone outside of the My Heart Counts Research Team unless you have selected to allow broader data sharing. Prior to sharing data outside of the My Heart Counts Research Team, researchers will need to denominated they are qualified to persome research that will review. Broadly shared data will have all information de-identified and not traceable to you.\n\nMoreover, the data will only be shared with qualified researchers who must submit applications to access de-identified data.\n\nYou can revoke this access at any time.\n"
+            "value" : "My Heart Counts needs read-access to automatically collect data such as heart rate, step counts, active calories, sleep durations, etc.\n\nYour data will not be shared with anyone outside of the My Heart Counts Research Team unless you have selected to allow broader data sharing. Prior to sharing data outside of the My Heart Counts Research Team, researchers will need to denominated they are qualified to persome research that will review. Broadly shared data will have all information de-identified and not traceable to you.\n\nMoreover, the data will only be shared with qualified researchers who must submit applications to access de-identified data.\n\nYou can revoke this access at any time."
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "My Heart Counts needs read-access to automatically collect data such as heart rate, step counts, active calories, sleep durations, etc.\n\nYour data will not be shared with anyone outside of the My Heart Counts Research Team unless you have selected to allow broader data sharing. Prior to sharing data outside of the My Heart Counts Research Team, researchers will need to denominated they are qualified to persome research that will review. Broadly shared data will have all information de-identified and not traceable to you.\n\nMoreover, the data will only be shared with qualified researchers who must submit applications to access de-identified data.\n\nYou can revoke this access at any time.\n"
+            "value" : "My Heart Counts needs read-access to automatically collect data such as heart rate, step counts, active calories, sleep durations, etc.\n\nYour data will not be shared with anyone outside of the My Heart Counts Research Team unless you have selected to allow broader data sharing. Prior to sharing data outside of the My Heart Counts Research Team, researchers will need to denominated they are qualified to persome research that will review. Broadly shared data will have all information de-identified and not traceable to you.\n\nMoreover, the data will only be shared with qualified researchers who must submit applications to access de-identified data.\n\nYou can revoke this access at any time."
           }
         }
       }
@@ -1050,29 +1101,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Su puntuación personalizada refleja su salud general basada en los factores que se enumeran a continuación. Sígala con el tiempo para ver cómo los cambios en el estilo de vida afectan la salud de su corazón."
-          }
-        }
-      }
-    },
-    "HEART_HEALTH_DASHBOARD_LEARN_MORE_TEXT" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "## Understanding Your My Heart Counts Health Score\n\n### What is this score?\nYour My Heart Counts Health Score provides a snapshot of your overall cardiovascular health based on the information you've shared with us. This score combines multiple factors that research has shown to be important for cardiovascular health.\n\n### How is it calculated?\nYour score incorporates:\n- Physical activity levels from your daily movement patterns\n- Heart health risk factors you reported in surveys (like blood pressure, cholesterol, if you know these)\n- Lifestyle factors such as diet, sleep, and overall mental health\n- Health behaviors like smoking status\n\n### What to do with this information:\n- **Track changes** over time to see how your heart health evolves. Understand that higher scores mean better overall health. By tracking your changes over time you can try and improve your overall health!\n- **Identify specific areas** where small changes might have the biggest impact.\n- **Set personal goals** based on which components have the most room for improvement. \n\nImportant note: This score is provided for research and educational purposes only. It is not a medical diagnosis and should not replace consultation with healthcare providers. The My Heart Counts Health Score is designed to encourage positive health behaviors and support your heart health journey."
-          }
-        },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "## Understanding Your My Heart Counts Health Score\n\n### What is this score?\nYour My Heart Counts Health Score provides a snapshot of your overall cardiovascular health based on the information you've shared with us. This score combines multiple factors that research has shown to be important for cardiovascular health.\n\n### How is it calculated?\nYour score incorporates:\n- Physical activity levels from your daily movement patterns\n- Heart health risk factors you reported in surveys (like blood pressure, cholesterol, if you know these)\n- Lifestyle factors such as diet, sleep, and overall mental health\n- Health behaviors like smoking status\n\n### What to do with this information:\n- **Track changes** over time to see how your heart health evolves. Understand that higher scores mean better overall health. By tracking your changes over time you can try and improve your overall health!\n- **Identify specific areas** where small changes might have the biggest impact.\n- **Set personal goals** based on which components have the most room for improvement. \n\nImportant note: This score is provided for research and educational purposes only. It is not a medical diagnosis and should not replace consultation with healthcare providers. The My Heart Counts Health Score is designed to encourage positive health behaviors and support your heart health journey."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "## Entienda su Puntuación de Salud de My Heart Counts\n\n### ¿Qué es esta puntuación?\nSu Puntuación de Salud de My Heart Counts proporciona una instantánea de su salud cardiovascular general basada en la información que ha compartido con nosotros. Esta puntuación combina varios factores que la investigación ha demostrado que son importantes para la salud cardiovascular.\n\n### ¿Cómo se calcula?\nSu puntuación incorpora:\n- Niveles de actividad física de sus patrones de movimiento diarios\n- Factores de riesgo para la salud del corazón que reportó en las encuestas (como presión arterial, colesterol - si los conoce)\n- Factores de estilo de vida como la dieta, el sueño y la salud mental en general\n- Comportamientos de salud como el estado de fumador\n\n### Qué hacer con esta información:\n- Rastree los cambios a lo largo del tiempo para ver cómo evoluciona la salud de su corazón. Entienda que puntuaciones más altas significan mejor salud en general. Al rastrear sus cambios a lo largo del tiempo, ¡puede intentar mejorar su salud general!\n- Identifique áreas específicas donde pequeños cambios puedan tener el mayor impacto.\n- Establezca metas personales basadas en qué componentes tienen más margen de mejora.\n\nNota importante: Esta puntuación se proporciona sólo con fines de investigación y educativos. No es un diagnóstico médico y no debe reemplazar la consulta con proveedores de atención médica. La Puntuación de Salud de My Heart Counts está diseñada para fomentar comportamientos de salud positivos y apoyar su viaje hacia la salud del corazón.\n\n\n\n"
+            "value" : "Tu puntuación personalizada refleja tu salud general basada en los factores que se enumeran a continuación. Síguela con el tiempo para ver cómo los cambios en el estilo de vida afectan la salud de su corazón."
           }
         }
       }
@@ -1130,7 +1159,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obtenga más información sobre My Heart Counts."
+            "value" : "Obtén más información sobre My Heart Counts."
           }
         }
       }
@@ -1146,7 +1175,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No es elegible para participar en este estudio porque no cumple con los criterios de elegibilidad."
+            "value" : "No eresre apto/a para participar en este estudio porque no cumpless con los criterios de admisión."
           }
         }
       }
@@ -1162,7 +1191,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No Elegible para Participar"
+            "value" : "No Apto para Participar"
           }
         }
       }
@@ -1412,7 +1441,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Por favor, permita que My Heart Counts le envíe notificaciones para que podamos llevar a cabo la investigación de manera adecuada.\n\nHaremos nuestro mejor esfuerzo para mantener las notificaciones al mínimo."
+            "value" : "Por favor, permite que My Heart Counts te envíe notificaciones para que podamos llevar a cabo la investigación de manera adecuada.\n\nMantenedremos las notificaciones al mínimo.\n"
           }
         }
       }
@@ -1458,8 +1487,14 @@
         },
         "en-GB" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "This research study is conducted by Stanford University School of Medicine researchers to understand how physical activity relates to cardiovascular health. The app will guide you through various assessments including the 6-minute walk test. Your participation is flexible meaning you can engage with the study as much or as little as you choose. The smartphone-based approach allows us to collect data in your natural environment rather than requiring visits to a clinical facility."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este estudio de investigación es realizado por investigadores de la Escuela de Medicina de la Universidad de Stanford para entender cómo la actividad física se relaciona con la salud cardiovascular. La aplicación te guiará a través de varias evaluaciones, incluyendo la prueba de caminata de 6 minutos. Tu participación es flexible, lo que significa que puedes participar en el estudio tanto como desees o tan poco como elijas. El enfoque basado en el smartphone nos permite recopilar datos en tu entorno natural en lugar de requerir visitas a una instalación clínica."
           }
         }
       }
@@ -1475,13 +1510,13 @@
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "You are invited to join an Imperial research study that uses physical activity collected from your smartphone to better understand how your previous, current and future levels of physical activity influence your your overall health today and in the future.\n\nYou’ll complete brief health surveys and perform simple fitness assessments like the 6-minute walk test using your phone.\n\nYou will also help us test whether personalised digital coaching can support improving your physical activity and health.\n"
+            "value" : "You are invited to join an Imperial research study that uses physical activity collected from your smartphone to better understand how your previous, current and future levels of physical activity influence your your overall health today and in the future. \n\nYou’ll complete brief health surveys and perform simple fitness assessments like the 6-minute walk test using your phone. \n\nYou will also help us test whether personalised digital coaching can support improving your physical activity and health.\n"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usted está invitado a unirse a un estudio de investigación de Stanford que rastrea la actividad física a través de su teléfono inteligente para mejorar el conocimiento sobre la salud del corazón. Completará breves encuestas de salud y realizará evaluaciones de condición física simples como la prueba de caminata de 6 minutos usando su teléfono."
+            "value" : "Te invitamos a unirte a un estudio de investigación de Stanford que rastrea la actividad física a través de tu smartphone para mejorar el conocimiento sobre la salud del corazón. \n\nSolo necesitas completar breves encuestas sobre tu salud y realizar evaluaciones de condición física simples como una prueba de esfuerzo de 6 minutos usando tu teléfono."
           }
         }
       }
@@ -1513,7 +1548,13 @@
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The optional trial uses a \"randomized crossover\" design where you'll experience both types of coaching interventions - personalized activity prompts and standard activity prompts - for 7 days each (total of 14 days). This will begin after the baseline monitoring week. The order in which you receive these interventions will be randomly assigned, similar to flipping a coin. This design allows researchers to compare how the different coaching approaches affect your activity levels while controlling for individual differences, as each participant serves as their own control. You can choose not to participate in this trial component and still be part of the main My Heart Counts study."
+            "value" : "The optional trial uses a \"randomized crossover\" design where you'll experience both types of coaching interventions - personalised activity prompts and standard activity prompts - for 7 days each (total of 14 days). This will begin after the baseline monitoring week. The order in which you receive these interventions will be randomly assigned, similar to flipping a coin. This design allows researchers to compare how the different coaching approaches affect your activity levels while controlling for individual differences, as each participant serves as their own control. You can choose not to participate in this trial component and still be part of the main My Heart Counts study."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El ensayo opcional utiliza un diseño de \"cruce aleatorio\" donde experimentarás ambos tipos de intervenciones de coaching: comandos de actividad personalizados y comandos de actividad estándar, durante 7 días cada uno (un total de 14 días). Esto comenzará después de la semana de monitoreo inicial. El orden en el que recibas estas intervenciones será asignado aleatoriamente, similar a lanzar una moneda. Este diseño permite a los investigadores comparar cómo los diferentes enfoques de coaching afectan tus niveles de actividad mientras se controlan las diferencias individuales, ya que cada participante sirve como su propio control. Puedes optar por no participar en este componente del ensayo y aún ser parte del estudio principal My Heart Counts."
           }
         }
       }
@@ -1523,19 +1564,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "You have the option to enroll in a 2-week physical activity coaching trial. If you choose to join, you'll experience both personalized and standard coaching messages for 7 days each, helping us learn which approaches better motivate healthy behaviors."
+            "value" : "You have the option to enroll in a 2-week physical activity coaching trial. If you choose to join, you’ll experience both personalized and standard coaching messages for 7 days each, helping us learn which approaches better motivate healthy behaviors."
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "You will have the option to enroll in a 2-week physical activity coaching trial. If you choose to join, you’ll experience both personalised and standard coaching messages for 7 days each, helping us learn which approaches better motivate healthy behaviors."
+            "value" : "You will have the option to enroll in a 2-week physical activity coaching trial. If you choose to join, you’ll experience both personalised and standard coaching messages for 7 days each, helping us learn which approaches better motivate healthy behaviours."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiene la opción de inscribirse en una prueba de entrenamiento físico de 2 semanas. Si decide unirse, experimentará tanto mensajes de entrenamiento personalizados como estándar durante 7 días cada uno, ayudándonos a aprender qué enfoques motivan mejor los comportamientos saludables."
+            "value" : "Elige inscribirte a una prueba de entrenamiento físico de dos semanas de duración. Si decides unite, recibirás mensajes personalizados ó estándares durante 7 días cada uno. Esto nos ayuda a entender qué métodos motivan más eficientemente comportamientos saludables."
           }
         }
       }
@@ -1589,7 +1630,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recopilaremos datos de la aplicación Salud en su iPhone, los cuales estarán protegidos mediante cifrado. Su información personal se almacena separadamente de los datos de salud, y usted controla qué datos de sensores y salud comparte con nosotros.\n\nAl aceptar este consentimiento, sus datos se combinarán con datos de otros participantes para ser analizados por los investigadores de Stanford y sus socios de investigación."
+            "value" : "Recopilaremos datos de la aplicación Salud en tu iPhone, los cuales estarán protegidos mediante encriptación. Tu información personal se almacena por separado de los datos de salud, y podrás controlar qué datos de sensores y salud compartes con nosotros.\n\nAl aceptar este consentimiento, tus datos se combinarán con datos de otros participantes para ser analizados por los investigadores de Stanford y sus socios de investigación."
           }
         }
       }
@@ -1629,6 +1670,12 @@
             "state" : "translated",
             "value" : "Physical risks are minimal but could include temporary muscle soreness or strain from fitness activities. There's also a small risk related to data privacy despite our security measures. Benefits include access to your own activity data and the knowledge that you're contributing to research that may help improve heart health recommendations. Your participation is entirely voluntary, and you can stop participating at any time without penalty by contacting the research team. This research has been reviewed by Stanford's Institutional Review Board to ensure participant protection."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los riesgos físicos son mínimos pero podrían incluir dolor muscular temporal o tensión debido a las actividades físicas. También hay un pequeño riesgo relacionado con la privacidad de los datos a pesar de nuestras medidas de seguridad. Los beneficios incluyen el acceso a tus propios datos de actividad y el conocimiento de que estás contribuyendo a una investigación que puede ayudar a mejorar las recomendaciones de salud cardíaca. Tu participación es completamente voluntaria y puedes dejar de participar en cualquier momento sin penalización contactando al equipo de investigación. Esta investigación ha sido revisada por la Comité de Ética en Investigación (CEI) de Stanford para asegurar la protección de los participantes."
+          }
         }
       }
     },
@@ -1637,19 +1684,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Participation is completely voluntary with minimal risks. Benefits include gaining insights about your heart health and contributing to cardiovascular research. You can withdraw from the study at anytime."
+            "value" : "Participation is completely voluntary with minimal risks. Benefits include gaining insights about your heart health and contributing to cardiovascular research. You can withdraw from the study at anytime and request to have your identifying data forgotten."
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Participation is completely voluntary with minimal risks. Benefits include gaining insights about your heart health and contributing to cardiovascular research. You can withdraw from the study at anytime."
+            "value" : "Participation is completely voluntary with minimal risks. Benefits include gaining insights about your heart health and contributing to cardiovascular research. You can withdraw from the study at anytime and request to have your identifying data forgotten."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La participación es completamente voluntaria y con riesgos mínimos. Los beneficios incluyen obtener información sobre la salud de su corazón y contribuir a la investigación cardiovascular. Puede retirarse del estudio en cualquier momento."
+            "value" : "La participación es completamente voluntaria y con riesgos mínimos. Los beneficios incluyen obtener información sobre la salud de su corazón y contribuir a la investigación cardiovascular. Puedes retirarte del estudio en cualquier momento y solicitar que se olvide tu información de identificación."
           }
         }
       }
@@ -2025,6 +2072,9 @@
     "Rhode Island" : {
 
     },
+    "run" : {
+
+    },
     "Sample" : {
 
     },
@@ -2231,6 +2281,54 @@
     "Timed Walking/Running Tests" : {
 
     },
+    "TIMED_WALK_TEST_EXPLAINER_6_MIN_WALK" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The 6-Minute Walk Test measures your functional exercise capacity by tracking how far you can walk in 6 minutes on a flat surface. It's a simple way to evaluate your physical fitness and is commonly used to monitor conditions affecting the heart and lungs.\n\nTo perform the test, find a flat path where you can walk without obstacles. Wear comfortable shoes. Tap \"Start\" and walk at a steady pace that's comfortable but challenging. Your goal is to cover as much distance as possible in 6 minutes."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "La Prueba de esfuerzo de 6 Minutos mide tu capacidad de ejercicio funcional al registrar qué tan lejos puedes caminar en 6 minutos en una superficie plana. Es una forma sencilla de evaluar tu condición física y se usa comúnmente para monitorear condiciones que afectan el corazón y los pulmones.\n\nPara realizar la prueba, encuentra una superficie plana donde puedas caminar sin obstáculos. Usa zapatos cómodos. Presiona \"Iniciar\" y camina a un ritmo constante que sea cómodo pero extenuante. Tu objetivo es recorrer la mayor distancia posible en 6 minutos."
+          }
+        }
+      }
+    },
+    "TIMED_WALK_TEST_EXPLAINER_12_MIN_RUN" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The 12-Minute Run Test measures your cardiovascular fitness by tracking how far you can run or jog in 12 minutes. This simple endurance test helps assess your aerobic fitness level and can be used to monitor progress over time. This test is best for people who already have some running experience.\n\nTo perform the test, find a flat area where you can run continuously without interruption. Wear appropriate running shoes and comfortable clothing. Warm up for 5-10 minutes with light jogging and stretching. When ready, tap \"Start\" on the app and begin running at a steady pace. Your goal is to cover as much distance as possible in the 12 minutes. Pace yourself - starting too fast might force you to slow down later. The app will alert you when 12 minutes have elapsed."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La Prueba de Carrera de 12 Minutos mide su aptitud cardiovascular al registrar cuán lejos puedes correr o trotar en 12 minutos. Esta simple prueba de resistencia ayuda a evaluar tu nivel de condición aeróbica y puede usarse para monitorear el progreso a lo largo del tiempo. Esta prueba es mejor para personas que ya tienen experiencia corriendo.\n\nPara realizar la prueba, encuentra un área plana donde puedas correr continuamente sin interrupciones. Usa zapatos para correr adecuados y ropa cómoda. Calienta durante 5-10 minutos con un trote ligero y estiramientos. Cuando estés listo/a, toca \"Iniciar\" en la aplicación y comienza a correr a un ritmo constante. Tu objetivo es recorrer la mayor distancia posible en los 12 minutos. Mantenga un paso constante - comenzar demasiado rápido podría ralentizarte más tarde. La aplicación te alertará cuando hayan pasado 12 minutos."
+          }
+        }
+      }
+    },
+    "TIMED_WALK_TEST_EXPLAINER_FOOTER" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop immediately if you experience chest pain, severe shortness of breath, dizziness, or unusual fatigue."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deténte inmediatamente si tienes dolor de pecho, dificultad respiratoria severa, mareos ó fatiga inusual."
+          }
+        }
+      }
+    },
     "Today" : {
 
     },
@@ -2391,6 +2489,9 @@
     "Virginia" : {
 
     },
+    "walk" : {
+
+    },
     "Warning Sign" : {
 
     },
@@ -2427,7 +2528,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Su participación ayuda a los investigadores de Stanford a comprender cómo el entrenamiento digital personalizado puede mejorar la actividad física y su salud general hoy y en el futuro."
+            "value" : "Tu participación ayuda a los investigadores de Stanford a comprender cómo el entrenamiento digital personalizado puede mejorar la actividad física y tu salud hoy y en el futuro."
           }
         }
       }
@@ -2449,7 +2550,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Contribuya a la Investigación de la Salud del Corazón"
+            "value" : "Contribuye a la Investigación de la Salud del Corazón"
           }
         }
       }
@@ -2471,7 +2572,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Experimente la versión rediseñada de una de las aplicaciones de estudios de investigación más grandes jamás realizadas."
+            "value" : "Experimenta la versión nueva de una de las aplicaciones basada en estudios de investigación más grande jamás realizada."
           }
         }
       }
@@ -2515,7 +2616,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Participe completamente en línea, compartiendo de manera segura sus datos de actividad directamente desde su iPhone y Apple Watch."
+            "value" : "Participa completamente en línea, compartiendo de manera segura tus datos de actividad directamente desde su iPhone y Apple Watch."
           }
         }
       }
@@ -2547,19 +2648,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Welcome to the My Heart Counts\nCardiovascular Health Study"
+            "value" : "Welcome to the My Heart Counts Cardiovascular Health Study"
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Welcome to the My Heart Counts\nCardiovascular Health Study"
+            "value" : "Welcome to the My Heart Counts Cardiovascular Health Study"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bienvenido al Estudio de Salud Cardiovascular My Heart Counts"
+            "state" : "needs_review",
+            "value" : "Bienvenido/a al Estudio de Salud Cardiovascular My Heart Counts"
           }
         }
       }
@@ -2572,7 +2673,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿En qué país vive actualmente?"
+            "value" : "¿En qué país vives actualmente?"
           }
         }
       }
@@ -2632,6 +2733,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Your Account"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Su Cuenta"
           }
         }
       }

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -37,6 +37,16 @@
     "#=%lld" : {
 
     },
+    "%@ – %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ – %2$@"
+          }
+        }
+      }
+    },
     "%@ (%lld)" : {
       "localizations" : {
         "en" : {
@@ -476,6 +486,9 @@
           }
         }
       }
+    },
+    "Always Available" : {
+
     },
     "American Samoa" : {
       "localizations" : {
@@ -3183,6 +3196,9 @@
         }
       }
     },
+    "Other Tasks" : {
+
+    },
     "Other Territories" : {
       "localizations" : {
         "es" : {
@@ -3222,6 +3238,9 @@
           }
         }
       }
+    },
+    "Past 2 Weeks" : {
+
     },
     "Past Data" : {
       "localizations" : {
@@ -3704,6 +3723,9 @@
           }
         }
       }
+    },
+    "Refresh" : {
+
     },
     "Region" : {
       "localizations" : {
@@ -4301,6 +4323,9 @@
         }
       }
     },
+    "Timed Walk Test" : {
+
+    },
     "Timed Walking Test" : {
       "localizations" : {
         "es" : {
@@ -4370,6 +4395,9 @@
       }
     },
     "Today" : {
+
+    },
+    "Today's Tasks" : {
 
     },
     "TODO: make this look pretty!" : {

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -154,7 +154,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "$35,000 – $49,999\n"
+            "value" : "$35,000 – $49,999"
           }
         }
       }
@@ -164,7 +164,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "$50,000 – $74,999\n"
+            "value" : "$50,000 – $74,999"
           }
         }
       }
@@ -174,7 +174,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "$75,000 – $99,999\n"
+            "value" : "$75,000 – $99,999"
           }
         }
       }
@@ -184,7 +184,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "$100,000 – $149,999\n"
+            "value" : "$100,000 – $149,999"
           }
         }
       }
@@ -194,7 +194,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "$150,000 y más\n"
+            "value" : "$150,000 y más"
           }
         }
       }
@@ -204,7 +204,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "£15,000 – £24,999\n"
+            "value" : "£15,000 – £24,999"
           }
         }
       }
@@ -214,7 +214,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "£25,000 – £34,999\n"
+            "value" : "£25,000 – £34,999"
           }
         }
       }
@@ -224,7 +224,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "£35,000 – £49,999\n"
+            "value" : "£35,000 – £49,999"
           }
         }
       }
@@ -234,7 +234,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "£50,000 – £74,999\n"
+            "value" : "£50,000 – £74,999"
           }
         }
       }
@@ -244,7 +244,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "£75,000 – £99,999\n"
+            "value" : "£75,000 – £99,999"
           }
         }
       }
@@ -254,7 +254,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "£100,000 – £149,999\n"
+            "value" : "£100,000 – £149,999"
           }
         }
       }
@@ -264,7 +264,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "£150,000 y más\n"
+            "value" : "£150,000 y más"
           }
         }
       }
@@ -284,7 +284,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 a 5 años atrás\n"
+            "value" : "1 a 5 años atrás"
           }
         }
       }
@@ -376,7 +376,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fumar activamente\n"
+            "value" : "Fumar activamente"
           }
         }
       }
@@ -396,7 +396,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Agregar Datos\n"
+            "value" : "Agregar Datos"
           }
         }
       }
@@ -406,7 +406,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Agregar Muestras de Altura y Peso\n"
+            "value" : "Agregar Muestras de Altura y Peso"
           }
         }
       }
@@ -416,7 +416,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Agregar Muestra\n"
+            "value" : "Agregar Muestra"
           }
         }
       }
@@ -456,7 +456,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Todas las Muestras\n"
+            "value" : "Todas las Muestras"
           }
         }
       }
@@ -466,7 +466,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¡Todas las tareas han sido completadas!\n"
+            "value" : "¡Todas las tareas han sido completadas!"
           }
         }
       }
@@ -495,7 +495,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Samoa Americana\n"
+            "value" : "Samoa Americana"
           }
         }
       }
@@ -505,7 +505,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Uso de la aplicación\n"
+            "value" : "Uso de la aplicación"
           }
         }
       }
@@ -525,7 +525,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Eres capaz de realizar actividades físicas?\n"
+            "value" : "¿Eres capaz de realizar actividades físicas?"
           }
         }
       }
@@ -535,7 +535,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Eres hispano/latino?\n"
+            "value" : "¿Eres hispano/latino?"
           }
         }
       }
@@ -545,7 +545,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Estás seguro de que deseas abandonar el estudio de '%@'?\n"
+            "value" : "¿Estás seguro de que deseas abandonar el estudio de '%@'?"
           }
         }
       }
@@ -578,7 +578,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sexo Biológico al Nacer\n"
+            "value" : "Sexo Biológico al Nacer"
           }
         }
       }
@@ -598,7 +598,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tipo de Sangre\n"
+            "value" : "Tipo de Sangre"
           }
         }
       }
@@ -608,7 +608,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gerente de Exportación Masiva\n"
+            "value" : "Gerente de Exportación Masiva"
           }
         }
       }
@@ -618,7 +618,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "id de paquete\n"
+            "value" : "id de paquete"
           }
         }
       }
@@ -628,7 +628,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "California\n"
+            "value" : "California"
           }
         }
       }
@@ -658,7 +658,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cambiar Idioma\n"
+            "value" : "Cambiar Idioma"
           }
         }
       }
@@ -726,7 +726,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enfermedad Cardíaca Congénita en Adultos\n"
+            "value" : "Enfermedad Cardíaca Congénita en Adultos"
           }
         }
       }
@@ -748,7 +748,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enfermedad Arterial Coronaria\n"
+            "value" : "Enfermedad Arterial Coronaria"
           }
         }
       }
@@ -792,7 +792,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuficiencia Cardíaca\n"
+            "value" : "Insuficiencia Cardíaca"
           }
         }
       }
@@ -836,7 +836,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hipertensión Arterial Pulmonar\n"
+            "value" : "Hipertensión Arterial Pulmonar"
           }
         }
       }
@@ -846,7 +846,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aplicación de Reloj Complementario No Instalada\n"
+            "value" : "Aplicación de Reloj Complementario No Instalada"
           }
         }
       }
@@ -999,7 +999,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fecha de Consentimiento\n"
+            "value" : "Fecha de Consentimiento"
           }
         }
       }
@@ -1009,7 +1009,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Documentos de Consentimiento\n"
+            "value" : "Documentos de Consentimiento"
           }
         }
       }
@@ -1019,7 +1019,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Renovación de Consentimiento\n"
+            "value" : "Renovación de Consentimiento"
           }
         }
       }
@@ -1029,7 +1029,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Versión de Consentimiento\n"
+            "value" : "Versión de Consentimiento"
           }
         }
       }
@@ -1059,7 +1059,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "orientación de la corona\n"
+            "value" : "orientación de la corona"
           }
         }
       }
@@ -1069,7 +1069,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prueba Actual\n"
+            "value" : "Prueba Actual"
           }
         }
       }
@@ -1099,7 +1099,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fecha de Nacimiento\n"
+            "value" : "Fecha de Nacimiento"
           }
         }
       }
@@ -1119,7 +1119,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Opciones de Depuración\n"
+            "value" : "Opciones de Depuración"
           }
         }
       }
@@ -1149,7 +1149,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eliminar y Restablecer Sesión\n"
+            "value" : "Eliminar y Restablecer Sesión"
           }
         }
       }
@@ -1169,7 +1169,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dependiendo de la cantidad de muestras, esto podría tardar un poco.\n"
+            "value" : "Dependiendo de la cantidad de muestras, esto podría tardar un poco."
           }
         }
       }
@@ -1199,7 +1199,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indicador de Divulgación\n"
+            "value" : "Indicador de Divulgación"
           }
         }
       }
@@ -1209,7 +1209,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Distrito de Columbia\n"
+            "value" : "Distrito de Columbia"
           }
         }
       }
@@ -1274,7 +1274,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nivel Educativo\n"
+            "value" : "Nivel Educativo"
           }
         }
       }
@@ -1284,7 +1284,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Región Efectiva\n"
+            "value" : "Región Efectiva"
           }
         }
       }
@@ -1338,7 +1338,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Habilitar Modo de Depuración de la Aplicación\n"
+            "value" : "Habilitar Modo de Depuración de la Aplicación"
           }
         }
       }
@@ -1348,7 +1348,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Finalizar Participación en el Estudio\n"
+            "value" : "Finalizar Participación en el Estudio"
           }
         }
       }
@@ -1358,7 +1358,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inscribirse en el Estudio\n"
+            "value" : "Inscribirse en el Estudio"
           }
         }
       }
@@ -1378,7 +1378,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingresar Presión Arterial\n"
+            "value" : "Ingresar Presión Arterial"
           }
         }
       }
@@ -1388,7 +1388,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingresar IMC (Índice de Masa Corporal)\n"
+            "value" : "Ingresar IMC (Índice de Masa Corporal)"
           }
         }
       }
@@ -1398,7 +1398,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingresar Altura\n"
+            "value" : "Ingresar Altura"
           }
         }
       }
@@ -1408,7 +1408,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingresar Peso\n"
+            "value" : "Ingresar Peso"
           }
         }
       }
@@ -1418,7 +1418,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Error\n"
+            "value" : "Error"
           }
         }
       }
@@ -1428,7 +1428,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Falló al Descargar Información del Estudio\n"
+            "value" : "Falló al Descargar Información del Estudio"
           }
         }
       }
@@ -1438,7 +1438,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Falló al Cargar el Estudio en la Aplicación\n"
+            "value" : "Falló al Cargar el Estudio en la Aplicación"
           }
         }
       }
@@ -1448,7 +1448,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Falló al procesar las Sesiones de Sueño\n"
+            "value" : "Falló al procesar las Sesiones de Sueño"
           }
         }
       }
@@ -1468,7 +1468,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Token de FCM\n"
+            "value" : "Token de FCM"
           }
         }
       }
@@ -1478,7 +1478,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Retroalimentación\n"
+            "value" : "Retroalimentación"
           }
         }
       }
@@ -1504,7 +1504,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¡Siéntete libre de volver más tarde!\n"
+            "value" : "¡Siéntete libre de volver más tarde!"
           }
         }
       }
@@ -1514,7 +1514,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obtener Resultados\n"
+            "value" : "Obtener Resultados"
           }
         }
       }
@@ -1524,7 +1524,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obtener Datos de Temperatura de Muñeca\n"
+            "value" : "Obtener Datos de Temperatura de Muñeca"
           }
         }
       }
@@ -1534,7 +1534,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obteniendo Datos…\n"
+            "value" : "Obteniendo Datos…"
           }
         }
       }
@@ -1544,7 +1544,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obteniendo…\n"
+            "value" : "Obteniendo…"
           }
         }
       }
@@ -1554,7 +1554,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Opciones de Filtro\n"
+            "value" : "Opciones de Filtro"
           }
         }
       }
@@ -1570,7 +1570,7 @@
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "What happens next:\n- Baseline Monitoring Week: Over the next 7 days, you’ll be guided through several short activities:\n    - Completing surveys about your health, lifestyle, and well-being\n    - Recording your baseline physical activity through the app\n    - Performing optimal fitness assessments if appropriate for your health status\n- Daily Tasks: Each day, you’ll see a personalized list of tasks in your dashboard. These typically take just 5-10 minutes to complete.\n- Data Collection: The app will begin collecting activity data from your phone and any connected wearable devices you’ve authorized.\n"
+            "value" : "What happens next:\n- Baseline Monitoring Week: Over the next 7 days, you’ll be guided through several short activities:\n    - Completing surveys about your health, lifestyle, and well-being\n    - Recording your baseline physical activity through the app\n    - Performing optimal fitness assessments if appropriate for your health status\n- Daily Tasks: Each day, you’ll see a personalized list of tasks in your dashboard. These typically take just 5-10 minutes to complete.\n- Data Collection: The app will begin collecting activity data from your phone and any connected wearable devices you’ve authorized."
           }
         },
         "es" : {
@@ -1620,7 +1620,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Después de tu semana basal, comenzarás el ensayo de 2 semanas comparando diferentes tipos de entrenamiento de actividad física. Recibirás notificaciones cuando esta fase comience.\n"
+            "value" : "Después de tu semana basal, comenzarás el ensayo de 2 semanas comparando diferentes tipos de entrenamiento de actividad física. Recibirás notificaciones cuando esta fase comience."
           }
         }
       }
@@ -1630,7 +1630,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Primeros 3 Dígitos del Código Postal\n"
+            "value" : "Primeros 3 Dígitos del Código Postal"
           }
         }
       }
@@ -1640,7 +1640,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Primera mitad del Código Postal\n"
+            "value" : "Primera mitad del Código Postal"
           }
         }
       }
@@ -1660,7 +1660,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Para obtener resultados óptimos, por favor, mantén tu teléfono en tu bolsillo y %@ hasta que vibre indicando que la prueba ha terminado.\n"
+            "value" : "Para obtener resultados óptimos, por favor, mantén tu teléfono en tu bolsillo y %@ hasta que vibre indicando que la prueba ha terminado."
           }
         }
       }
@@ -1670,7 +1670,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Para obtener resultados óptimos, por favor, mantén tu teléfono en tu bolsillo y %@ hasta que tu reloj vibre indicando que la prueba ha terminado.\n"
+            "value" : "Para obtener resultados óptimos, por favor, mantén tu teléfono en tu bolsillo y %@ hasta que tu reloj vibre indicando que la prueba ha terminado."
           }
         }
       }
@@ -1680,7 +1680,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estudios Futuros\n"
+            "value" : "Estudios Futuros"
           }
         }
       }
@@ -1690,7 +1690,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Identidad de Género\n"
+            "value" : "Identidad de Género"
           }
         }
       }
@@ -1712,7 +1712,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Femenino\n"
+            "value" : "Femenino"
           }
         }
       }
@@ -1756,7 +1756,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Variante de género / No conforme\n"
+            "value" : "Variante de género / No conforme"
           }
         }
       }
@@ -1778,7 +1778,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prefiero no declarar\n"
+            "value" : "Prefiero no declarar"
           }
         }
       }
@@ -1800,7 +1800,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mujer transgénero\n"
+            "value" : "Mujer transgénero"
           }
         }
       }
@@ -1822,7 +1822,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hombre transgénero\n"
+            "value" : "Hombre transgénero"
           }
         }
       }
@@ -1842,7 +1842,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ir al siguiente campo\n"
+            "value" : "Ir al siguiente campo"
           }
         }
       }
@@ -1852,7 +1852,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ir al campo anterior\n"
+            "value" : "Ir al campo anterior"
           }
         }
       }
@@ -1868,7 +1868,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conceder acceso\n"
+            "value" : "Conceder acceso"
           }
         }
       }
@@ -1898,7 +1898,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Datos de salud\n"
+            "value" : "Datos de salud"
           }
         }
       }
@@ -1908,7 +1908,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Carga masiva de datos de salud\n"
+            "value" : "Carga masiva de datos de salud"
           }
         }
       }
@@ -1924,7 +1924,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Acceso a HealthKit\n"
+            "value" : "Acceso a HealthKit"
           }
         }
       }
@@ -2030,7 +2030,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingreso Familiar\n"
+            "value" : "Ingreso Familiar"
           }
         }
       }
@@ -2040,7 +2040,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nunca he fumado\n"
+            "value" : "Nunca he fumado"
           }
         }
       }
@@ -2050,7 +2050,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fumé por última vez entre 1 y 5 años atrás\n"
+            "value" : "Fumé por última vez entre 1 y 5 años atrás"
           }
         }
       }
@@ -2060,7 +2060,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fumé por última vez hace más de 5 años\n"
+            "value" : "Fumé por última vez hace más de 5 años"
           }
         }
       }
@@ -2070,7 +2070,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fumé por última vez en el último año, o estoy usando NDS\n"
+            "value" : "Fumé por última vez en el último año, o estoy usando NDS"
           }
         }
       }
@@ -2080,7 +2080,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estoy fumando activamente\n"
+            "value" : "Estoy fumando activamente"
           }
         }
       }
@@ -2110,7 +2110,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "identificador\n"
+            "value" : "identificador"
           }
         }
       }
@@ -2120,7 +2120,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Si tienes un Apple Watch, asegúrate de que la aplicación Mi Corazón Cuenta esté en funcionamiento\n"
+            "value" : "Si tienes un Apple Watch, asegúrate de que la aplicación Mi Corazón Cuenta esté en funcionamiento"
           }
         }
       }
@@ -2130,7 +2130,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ignorar Resultados Vacíos\n"
+            "value" : "Ignorar Resultados Vacíos"
           }
         }
       }
@@ -2208,7 +2208,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Instalar en Apple Watch\n"
+            "value" : "Instalar en Apple Watch"
           }
         }
       }
@@ -2218,7 +2218,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Instalar Mi Corazón Cuenta en tu Apple Watch nos permitirá aumentar considerablemente la calidad de los datos registrados.\n"
+            "value" : "Instalar Mi Corazón Cuenta en tu Apple Watch nos permitirá aumentar considerablemente la calidad de los datos registrados."
           }
         }
       }
@@ -2268,7 +2268,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Latino / Hispano?\n"
+            "value" : "¿Latino / Hispano?"
           }
         }
       }
@@ -2278,7 +2278,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Iniciar la Aplicación del Reloj\n"
+            "value" : "Iniciar la Aplicación del Reloj"
           }
         }
       }
@@ -2294,7 +2294,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aprender Más\n"
+            "value" : "Aprender Más"
           }
         }
       }
@@ -2304,7 +2304,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Menos de $15,000\n"
+            "value" : "Menos de $15,000"
           }
         }
       }
@@ -2314,7 +2314,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Menos de £15,000\n"
+            "value" : "Menos de £15,000"
           }
         }
       }
@@ -2330,7 +2330,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Información de Licencia\n"
+            "value" : "Información de Licencia"
           }
         }
       }
@@ -2340,7 +2340,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Símbolo de Flecha de Enlace\n"
+            "value" : "Símbolo de Flecha de Enlace"
           }
         }
       }
@@ -2350,7 +2350,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Notificaciones de Carga de Salud en Vivo\n"
+            "value" : "Notificaciones de Carga de Salud en Vivo"
           }
         }
       }
@@ -2360,7 +2360,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cargando Configuración de Prueba de Firebase\n"
+            "value" : "Cargando Configuración de Prueba de Firebase"
           }
         }
       }
@@ -2370,7 +2370,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estado de Notificaciones Locales\n"
+            "value" : "Estado de Notificaciones Locales"
           }
         }
       }
@@ -2410,7 +2410,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Asegúrate de que tu dispositivo esté conectado a Internet y vuelve a intentarlo\n"
+            "value" : "Asegúrate de que tu dispositivo esté conectado a Internet y vuelve a intentarlo"
           }
         }
       }
@@ -2440,7 +2440,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Entrada Coincidente\n"
+            "value" : "Entrada Coincidente"
           }
         }
       }
@@ -2450,7 +2450,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Podemos ponernos en contacto contigo sobre estudios futuros que puedan interesarte?\n"
+            "value" : "¿Podemos ponernos en contacto contigo sobre estudios futuros que puedan interesarte?"
           }
         }
       }
@@ -2480,7 +2480,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tareas Perdidas\n"
+            "value" : "Tareas Perdidas"
           }
         }
       }
@@ -2490,7 +2490,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Faltando Permiso de Acceso a Datos de Movimiento Requerido\n"
+            "value" : "Faltando Permiso de Acceso a Datos de Movimiento Requerido"
           }
         }
       }
@@ -2530,7 +2530,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hace más de 5 años\n"
+            "value" : "Hace más de 5 años"
           }
         }
       }
@@ -2576,7 +2576,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Problema de Red\n"
+            "value" : "Problema de Red"
           }
         }
       }
@@ -2586,7 +2586,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nevada\n"
+            "value" : "Nevada"
           }
         }
       }
@@ -2606,7 +2606,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nueva Hampshire\n"
+            "value" : "Nueva Hampshire"
           }
         }
       }
@@ -2616,7 +2616,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nueva Jersey\n"
+            "value" : "Nueva Jersey"
           }
         }
       }
@@ -2626,7 +2626,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nuevo México\n"
+            "value" : "Nuevo México"
           }
         }
       }
@@ -2636,7 +2636,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nueva York\n"
+            "value" : "Nueva York"
           }
         }
       }
@@ -2656,7 +2656,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Noticias e Información\n"
+            "value" : "Noticias e Información"
           }
         }
       }
@@ -2682,7 +2682,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Número NHS\n"
+            "value" : "Número NHS"
           }
         }
       }
@@ -2692,7 +2692,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Número NHS (Opcional)\n"
+            "value" : "Número NHS (Opcional)"
           }
         }
       }
@@ -2722,7 +2722,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sin Datos\n"
+            "value" : "Sin Datos"
           }
         }
       }
@@ -2732,7 +2732,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sin Internet\n"
+            "value" : "Sin Internet"
           }
         }
       }
@@ -2742,7 +2742,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No hay Tareas Perdidas\n"
+            "value" : "No hay Tareas Perdidas"
           }
         }
       }
@@ -2752,7 +2752,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No hay Noticias Aún\n"
+            "value" : "No hay Noticias Aún"
           }
         }
       }
@@ -2762,7 +2762,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No hay Tareas Próximas\n"
+            "value" : "No hay Tareas Próximas"
           }
         }
       }
@@ -2772,7 +2772,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No, no soy hispano/latino\n"
+            "value" : "No, no soy hispano/latino"
           }
         }
       }
@@ -2782,7 +2782,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Carolina del Norte\n"
+            "value" : "Carolina del Norte"
           }
         }
       }
@@ -2792,7 +2792,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dakota del Norte\n"
+            "value" : "Dakota del Norte"
           }
         }
       }
@@ -2802,7 +2802,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Islas Marianas del Norte\n"
+            "value" : "Islas Marianas del Norte"
           }
         }
       }
@@ -2812,7 +2812,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No ha iniciado sesión\n"
+            "value" : "No ha iniciado sesión"
           }
         }
       }
@@ -2822,7 +2822,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No Establecido\n"
+            "value" : "No Establecido"
           }
         }
       }
@@ -2870,7 +2870,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estado de Notificaciones\n"
+            "value" : "Estado de Notificaciones"
           }
         }
       }
@@ -2883,7 +2883,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ohio\n"
+            "value" : "Ohio"
           }
         }
       }
@@ -2903,7 +2903,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oklahoma\n"
+            "value" : "Oklahoma"
           }
         }
       }
@@ -2925,7 +2925,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este estudio de investigación es llevado a cabo por investigadores de la Facultad de Medicina de la Universidad de Stanford para entender cómo la actividad física se relaciona con la salud cardiovascular. La aplicación te guiará a través de varias evaluaciones, incluyendo la prueba de caminata de 6 minutos. Tu participación es flexible, lo que significa que puedes participar en el estudio tanto como desees. El enfoque basado en teléfonos inteligentes nos permite recopilar datos en tu entorno natural en lugar de requerir visitas a una instalación clínica.\n"
+            "value" : "Este estudio de investigación es llevado a cabo por investigadores de la Facultad de Medicina de la Universidad de Stanford para entender cómo la actividad física se relaciona con la salud cardiovascular. La aplicación te guiará a través de varias evaluaciones, incluyendo la prueba de caminata de 6 minutos. Tu participación es flexible, lo que significa que puedes participar en el estudio tanto como desees. El enfoque basado en teléfonos inteligentes nos permite recopilar datos en tu entorno natural en lugar de requerir visitas a una instalación clínica."
           }
         }
       }
@@ -2941,7 +2941,7 @@
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "You are invited to join an Imperial research study that uses physical activity collected from your smartphone to better understand how your previous, current and future levels of physical activity influence your your overall health today and in the future. \n\nYou’ll complete brief health surveys and perform simple fitness assessments like the 6-minute walk test using your phone. \n\nYou will also help us test whether personalised digital coaching can support improving your physical activity and health.\n"
+            "value" : "You are invited to join an Imperial research study that uses physical activity collected from your smartphone to better understand how your previous, current and future levels of physical activity influence your your overall health today and in the future. \n\nYou’ll complete brief health surveys and perform simple fitness assessments like the 6-minute walk test using your phone. \n\nYou will also help us test whether personalised digital coaching can support improving your physical activity and health."
           }
         },
         "es" : {
@@ -3171,7 +3171,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abrir en el navegador\n"
+            "value" : "Abrir en el navegador"
           }
         }
       }
@@ -3181,7 +3181,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abrir configuración\n"
+            "value" : "Abrir configuración"
           }
         }
       }
@@ -3191,7 +3191,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oregón\n"
+            "value" : "Oregón"
           }
         }
       }
@@ -3204,7 +3204,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Otros territorios\n"
+            "value" : "Otros territorios"
           }
         }
       }
@@ -3214,7 +3214,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nuestro documento de consentimiento del estudio ha sido actualizado desde la última vez que lo firmaste %@.\n\nPor favor, revisa el nuevo documento de consentimiento y fírmalo nuevamente.\n"
+            "value" : "Nuestro documento de consentimiento del estudio ha sido actualizado desde la última vez que lo firmaste %@.\n\nPor favor, revisa el nuevo documento de consentimiento y fírmalo nuevamente."
           }
         }
       }
@@ -3224,7 +3224,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Anular región\n"
+            "value" : "Anular región"
           }
         }
       }
@@ -3234,7 +3234,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Criterios de participación\n"
+            "value" : "Criterios de participación"
           }
         }
       }
@@ -3247,7 +3247,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Datos pasados\n"
+            "value" : "Datos pasados"
           }
         }
       }
@@ -3269,7 +3269,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Resultados de pruebas de caminata/corrida cronometradas pasadas\n"
+            "value" : "Resultados de pruebas de caminata/corrida cronometradas pasadas"
           }
         }
       }
@@ -3289,7 +3289,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Porcentaje en fase\n"
+            "value" : "Porcentaje en fase"
           }
         }
       }
@@ -3309,7 +3309,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Actividad Física\n"
+            "value" : "Actividad Física"
           }
         }
       }
@@ -3329,7 +3329,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Procesando datos de salud...\n"
+            "value" : "Procesando datos de salud..."
           }
         }
       }
@@ -3339,7 +3339,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Procesando datos de sueño...\n"
+            "value" : "Procesando datos de sueño..."
           }
         }
       }
@@ -3349,7 +3349,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Puerto Rico\n"
+            "value" : "Puerto Rico"
           }
         }
       }
@@ -3359,7 +3359,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Raza / Etnicidad\n"
+            "value" : "Raza / Etnicidad"
           }
         }
       }
@@ -3381,7 +3381,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afroamericano\n"
+            "value" : "Afroamericano"
           }
         }
       }
@@ -3403,7 +3403,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nativo de Alaska\n"
+            "value" : "Nativo de Alaska"
           }
         }
       }
@@ -3425,7 +3425,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indígena Americano\n"
+            "value" : "Indígena Americano"
           }
         }
       }
@@ -3447,7 +3447,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indio Asiático\n"
+            "value" : "Indio Asiático"
           }
         }
       }
@@ -3557,7 +3557,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sin selección\n"
+            "value" : "Sin selección"
           }
         }
       }
@@ -3601,7 +3601,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Isleño del Pacífico\n"
+            "value" : "Isleño del Pacífico"
           }
         }
       }
@@ -3623,7 +3623,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prefiero no responder\n"
+            "value" : "Prefiero no responder"
           }
         }
       }
@@ -3645,7 +3645,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Puedes seleccionar múltiples opciones.\n"
+            "value" : "Puedes seleccionar múltiples opciones."
           }
         }
       }
@@ -3667,7 +3667,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vietnamita\n"
+            "value" : "Vietnamita"
           }
         }
       }
@@ -3699,7 +3699,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Leer artículo\n"
+            "value" : "Leer artículo"
           }
         }
       }
@@ -3709,7 +3709,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Leer desde la aplicación de salud\n"
+            "value" : "Leer desde la aplicación de salud"
           }
         }
       }
@@ -3719,13 +3719,10 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Datos recientes de sueño\n"
+            "value" : "Datos recientes de sueño"
           }
         }
       }
-    },
-    "Refresh" : {
-
     },
     "Region" : {
       "localizations" : {
@@ -3742,7 +3739,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Registro de Notificaciones Remotas\n"
+            "value" : "Registro de Notificaciones Remotas"
           }
         }
       }
@@ -3752,7 +3749,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reemplazar el Controlador de Vista Raíz\n"
+            "value" : "Reemplazar el Controlador de Vista Raíz"
           }
         }
       }
@@ -3765,7 +3762,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Solicitar Permisos\n"
+            "value" : "Solicitar Permisos"
           }
         }
       }
@@ -3775,7 +3772,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Resultados\n"
+            "value" : "Resultados"
           }
         }
       }
@@ -3785,7 +3782,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reintentar\n"
+            "value" : "Reintentar"
           }
         }
       }
@@ -3795,7 +3792,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Revisar Formularios de Consentimiento\n"
+            "value" : "Revisar Formularios de Consentimiento"
           }
         }
       }
@@ -3805,7 +3802,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rhode Island\n"
+            "value" : "Rhode Island"
           }
         }
       }
@@ -3818,7 +3815,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Muestra\n"
+            "value" : "Muestra"
           }
         }
       }
@@ -3828,7 +3825,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tipo de Muestra\n"
+            "value" : "Tipo de Muestra"
           }
         }
       }
@@ -3851,7 +3848,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Notificaciones Locales Programadas\n"
+            "value" : "Notificaciones Locales Programadas"
           }
         }
       }
@@ -3861,7 +3858,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Resultado de Puntaje\n"
+            "value" : "Resultado de Puntaje"
           }
         }
       }
@@ -3871,7 +3868,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Selecciona una Región\n"
+            "value" : "Selecciona una Región"
           }
         }
       }
@@ -3881,7 +3878,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Selecciona un Condado\n"
+            "value" : "Selecciona un Condado"
           }
         }
       }
@@ -3891,7 +3888,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Selecciona tu Estado o Territorio\n"
+            "value" : "Selecciona tu Estado o Territorio"
           }
         }
       }
@@ -3921,7 +3918,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Marca de selección\n"
+            "value" : "Marca de selección"
           }
         }
       }
@@ -3931,7 +3928,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enviar\n"
+            "value" : "Enviar"
           }
         }
       }
@@ -3941,7 +3938,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enviar Comentarios\n"
+            "value" : "Enviar Comentarios"
           }
         }
       }
@@ -3951,7 +3948,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensores\n"
+            "value" : "Sensores"
           }
         }
       }
@@ -4005,7 +4002,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Intersex\n"
+            "value" : "Intersex"
           }
         }
       }
@@ -4049,7 +4046,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prefiero no declarar\n"
+            "value" : "Prefiero no declarar"
           }
         }
       }
@@ -4059,7 +4056,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fase del Sueño\n"
+            "value" : "Fase del Sueño"
           }
         }
       }
@@ -4069,7 +4066,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Carolina del Sur\n"
+            "value" : "Carolina del Sur"
           }
         }
       }
@@ -4079,7 +4076,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dakota del Sur\n"
+            "value" : "Dakota del Sur"
           }
         }
       }
@@ -4089,7 +4086,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Iniciar Todo\n"
+            "value" : "Iniciar Todo"
           }
         }
       }
@@ -4099,7 +4096,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Iniciar Prueba\n"
+            "value" : "Iniciar Prueba"
           }
         }
       }
@@ -4119,7 +4116,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detener Todo\n"
+            "value" : "Detener Todo"
           }
         }
       }
@@ -4129,7 +4126,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Información del Estudio\n"
+            "value" : "Información del Estudio"
           }
         }
       }
@@ -4139,7 +4136,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estudio no disponible\n"
+            "value" : "Estudio no disponible"
           }
         }
       }
@@ -4149,7 +4146,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Participación en el Estudio\n"
+            "value" : "Participación en el Estudio"
           }
         }
       }
@@ -4175,7 +4172,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Categorías Suplementarias\n"
+            "value" : "Categorías Suplementarias"
           }
         }
       }
@@ -4185,7 +4182,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Realizar Prueba\n"
+            "value" : "Realizar Prueba"
           }
         }
       }
@@ -4208,7 +4205,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prueba\n"
+            "value" : "Prueba"
           }
         }
       }
@@ -4218,7 +4215,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Soporte de Pruebas\n"
+            "value" : "Soporte de Pruebas"
           }
         }
       }
@@ -4238,7 +4235,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La aplicación pudo descargar el estudio, pero no pudo decodificarlo. Asegúrate de tener instalada la versión más reciente.\n"
+            "value" : "La aplicación pudo descargar el estudio, pero no pudo decodificarlo. Asegúrate de tener instalada la versión más reciente."
           }
         }
       }
@@ -4248,7 +4245,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La aplicación no pudo cargar el estudio, pero no estamos seguros de por qué\n"
+            "value" : "La aplicación no pudo cargar el estudio, pero no estamos seguros de por qué"
           }
         }
       }
@@ -4258,7 +4255,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La Prueba de Caminata cronometrada requiere acceso de lectura a los Datos de Movimiento y Fitness.\n"
+            "value" : "La Prueba de Caminata cronometrada requiere acceso de lectura a los Datos de Movimiento y Fitness."
           }
         }
       }
@@ -4268,7 +4265,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este estudio solicitará acceso de lectura para recopilar las siguientes muestras de Salud:\n"
+            "value" : "Este estudio solicitará acceso de lectura para recopilar las siguientes muestras de Salud:"
           }
         }
       }
@@ -4278,7 +4275,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiempo Dormido\n"
+            "value" : "Tiempo Dormido"
           }
         }
       }
@@ -4288,7 +4285,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiempo Transcurrido\n"
+            "value" : "Tiempo Transcurrido"
           }
         }
       }
@@ -4298,7 +4295,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Información del Tiempo\n"
+            "value" : "Información del Tiempo"
           }
         }
       }
@@ -4308,7 +4305,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiempo Restante\n"
+            "value" : "Tiempo Restante"
           }
         }
       }
@@ -4318,7 +4315,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zona Horaria\n"
+            "value" : "Zona Horaria"
           }
         }
       }
@@ -4331,7 +4328,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prueba de Caminata Cronometrada\n"
+            "value" : "Prueba de Caminata Cronometrada"
           }
         }
       }
@@ -4341,7 +4338,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pruebas de Caminata/Corrida Cronometradas\n"
+            "value" : "Pruebas de Caminata/Corrida Cronometradas"
           }
         }
       }
@@ -4411,7 +4408,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingreso Total del Hogar\n"
+            "value" : "Ingreso Total del Hogar"
           }
         }
       }
@@ -4520,7 +4517,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No se pudo encontrar el Cuestionario\n"
+            "value" : "No se pudo encontrar el Cuestionario"
           }
         }
       }
@@ -4530,7 +4527,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No se pudo cargar los datos\n"
+            "value" : "No se pudo cargar los datos"
           }
         }
       }
@@ -4540,7 +4537,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Darse de baja\n"
+            "value" : "Darse de baja"
           }
         }
       }
@@ -4570,7 +4567,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cargando Datos de Salud\n"
+            "value" : "Cargando Datos de Salud"
           }
         }
       }
@@ -4580,7 +4577,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estado / Región de EE. UU.\n"
+            "value" : "Estado / Región de EE. UU."
           }
         }
       }
@@ -4590,7 +4587,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estado / Territorio de EE. UU.\n"
+            "value" : "Estado / Territorio de EE. UU."
           }
         }
       }
@@ -4600,7 +4597,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Utiliza esta opción para autocompletar el Tipo de Sangre, Altura, Peso, Fecha de Nacimiento y Sexo Biológico, leyendo cada uno desde la aplicación de Salud, si está disponible. Alternativamente, también puedes tocar los campos respectivos a continuación para ingresar un valor manualmente, o para sobrescribir el valor leído de la aplicación de Salud.\n"
+            "value" : "Utiliza esta opción para autocompletar el Tipo de Sangre, Altura, Peso, Fecha de Nacimiento y Sexo Biológico, leyendo cada uno desde la aplicación de Salud, si está disponible. Alternativamente, también puedes tocar los campos respectivos a continuación para ingresar un valor manualmente, o para sobrescribir el valor leído de la aplicación de Salud."
           }
         }
       }
@@ -4640,7 +4637,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Islas Vírgenes\n"
+            "value" : "Islas Vírgenes"
           }
         }
       }
@@ -4663,7 +4660,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Señal de Advertencia\n"
+            "value" : "Señal de Advertencia"
           }
         }
       }
@@ -4857,7 +4854,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Virginia Occidental\n"
+            "value" : "Virginia Occidental"
           }
         }
       }
@@ -4887,7 +4884,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En el último año, o estoy usando NDS\n"
+            "value" : "En el último año, o estoy usando NDS"
           }
         }
       }
@@ -4930,7 +4927,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sí, Hispano del Caribe, incluyendo Cubano y Puertorriqueño\n"
+            "value" : "Sí, Hispano del Caribe, incluyendo Cubano y Puertorriqueño"
           }
         }
       }
@@ -4940,7 +4937,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sí, Hispano Europeo, incluyendo Español y Portugués, Hispano, Latina\n"
+            "value" : "Sí, Hispano Europeo, incluyendo Español y Portugués, Hispano, Latina"
           }
         }
       }
@@ -4950,7 +4947,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sí, Mexicano, Mexicano Americano, o Chicano\n"
+            "value" : "Sí, Mexicano, Mexicano Americano, o Chicano"
           }
         }
       }
@@ -4960,7 +4957,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sí, otro Hispano, Latino\n"
+            "value" : "Sí, otro Hispano, Latino"
           }
         }
       }
@@ -4970,7 +4967,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sí, Hispano Sudamericano\n"
+            "value" : "Sí, Hispano Sudamericano"
           }
         }
       }
@@ -4983,7 +4980,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Puedes seleccionar múltiples opciones\n"
+            "value" : "Puedes seleccionar múltiples opciones"
           }
         }
       }
@@ -4993,7 +4990,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¡Estás listo!\n"
+            "value" : "¡Estás listo!"
           }
         }
       }
@@ -5009,7 +5006,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tu Cuenta\n"
+            "value" : "Tu Cuenta"
           }
         }
       }

--- a/MyHeartCounts/Supporting Files/InfoPlist.xcstrings
+++ b/MyHeartCounts/Supporting Files/InfoPlist.xcstrings
@@ -14,7 +14,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mi Corazón Cuenta"
+            "value" : "My Heart Counts"
           }
         }
       }
@@ -26,6 +26,12 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "MyHeartCounts"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "MyHeartCounts"
           }
         }

--- a/MyHeartCounts/Upcoming Tasks Tab/TasksList.swift
+++ b/MyHeartCounts/Upcoming Tasks Tab/TasksList.swift
@@ -52,7 +52,7 @@ struct TasksList: View {
     
     enum HeaderConfig {
         case none
-        case custom(String, subtitle: String = "")
+        case custom(LocalizedStringResource, subtitle: LocalizedStringResource? = nil)
         case timeRange
     }
     
@@ -178,14 +178,14 @@ struct TasksList: View {
         )
     }
     
-    private var headerContents: (String, String) {
+    private var headerContents: (LocalizedStringResource, LocalizedStringResource?) {
         switch headerConfig {
         case .none:
-            return ("", "")
+            return ("", nil)
         case let .custom(title, subtitle):
             return (title, subtitle)
         case .timeRange:
-            let (title, needsSubtitle) = switch timeRange {
+            let (title, needsSubtitle): (LocalizedStringResource, Bool) = switch timeRange {
             case .days(1):
                 ("Today", false)
             case .days(let numDays):
@@ -205,7 +205,7 @@ struct TasksList: View {
                 let end = timeRange.upperBound.addingTimeInterval(-1).formatted(date: .numeric, time: .omitted)
                 return (title, "\(start) – \(end)")
             } else {
-                return (title, "")
+                return (title, nil)
             }
         }
     }

--- a/MyHeartCounts/Upcoming Tasks Tab/UpcomingTasksTab.swift
+++ b/MyHeartCounts/Upcoming Tasks Tab/UpcomingTasksTab.swift
@@ -59,28 +59,28 @@ struct UpcomingTasksTab: RootViewTab {
                 }
             }
         } label: {
-            Label("Timed Walking Test", systemSymbol: .figureWalk)
+            Label("Timed Walk Test", systemSymbol: .figureWalk)
         }
     }
 }
 
 
 extension UpcomingTasksTab {
-    static func sectionHeader(
-        title: LocalizedStringResource,
-        subtitle: LocalizedStringResource?
-    ) -> some View {
-        sectionHeader(title: title.localizedString(), subtitle: subtitle?.localizedString() ?? "")
-    }
+//    static func sectionHeader(
+//        title: LocalizedStringResource,
+//        subtitle: LocalizedStringResource?
+//    ) -> some View {
+//        sectionHeader(title: title.localizedString(), subtitle: subtitle?.localizedString() ?? "")
+//    }
     
     static func sectionHeader(
-        title: some StringProtocol,
-        subtitle: some StringProtocol = ""
+        title: LocalizedStringResource,
+        subtitle: LocalizedStringResource? = nil
     ) -> some View {
         Section {
             VStack(alignment: .leading) {
                 Text(title)
-                if !subtitle.isEmpty {
+                if let subtitle, !String(localized: subtitle).isEmpty {
                     Text(subtitle)
                         .foregroundStyle(.secondary)
                         .font(.footnote)

--- a/MyHeartCounts/Utils/Range+Date.swift
+++ b/MyHeartCounts/Utils/Range+Date.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SpeziFoundation
+
+
+extension Range where Bound == Date {
+    func displayText(using cal: Calendar) -> String {
+        // would it maybe make sense to have a "TimeRangeLabel"?
+        // certainly space for improvement here...
+        if self == cal.rangeOfDay(for: .now) {
+            return String(localized: "Today")
+        } else if self == cal.rangeOfDay(for: cal.startOfPrevDay(for: .now)) {
+            return String(localized: "Yesterday")
+        } else if self == cal.rangeOfDay(for: self.lowerBound) {
+            return "\(self.lowerBound.formatted(date: .abbreviated, time: .omitted))"
+        } else if self.isEmpty, case let date = self.lowerBound { // startDate == endDate
+            return if cal.isDateInToday(date) && date <= .now {
+                "\(date.formatted(date: .omitted, time: .shortened))"
+            } else {
+                // is older than today
+                "\(date.formatted(date: .numeric, time: .shortened))"
+            }
+        } else if cal.isDate(lowerBound, inSameDayAs: upperBound) {
+            if cal.isDateInToday(upperBound) {
+                return String(localized: "Today")
+            } else if cal.isDateInYesterday(upperBound) {
+                return String(localized: "Yesterday")
+            } else {
+                return "\(lowerBound.formatted(date: .abbreviated, time: .omitted))"
+            }
+        } else {
+            let fmt = { ($0 as Date).formatted(date: .abbreviated, time: .omitted) }
+            return "\(fmt(self.lowerBound)) – \(fmt(self.upperBound.addingTimeInterval(-1)))"
+        }
+    }
+}

--- a/MyHeartCountsUITests/AOnboardingTests.swift
+++ b/MyHeartCountsUITests/AOnboardingTests.swift
@@ -56,7 +56,9 @@ extension XCUIApplication {
     
     
     private func navigateWelcome() {
-        XCTAssert(staticTexts["Welcome to the My Heart Counts\nCardiovascular Health Study"].waitForExistence(timeout: 2))
+        let predicate = NSPredicate(format: "label MATCHES 'Welcome to the My Heart Counts(\n| )Cardiovascular Health Study'")
+        XCTAssert(staticTexts.element(matching: predicate).waitForExistence(timeout: 2))
+        //XCTAssert(staticTexts["Welcome to the My Heart Counts\nCardiovascular Health Study"].waitForExistence(timeout: 2))
         buttons["Continue"].tap()
     }
     

--- a/MyHeartCountsUITests/AOnboardingTests.swift
+++ b/MyHeartCountsUITests/AOnboardingTests.swift
@@ -56,7 +56,7 @@ extension XCUIApplication {
     
     
     private func navigateWelcome() {
-        let predicate = NSPredicate(format: "label MATCHES 'Welcome to the My Heart Counts(\n| )Cardiovascular Health Study'")
+        let predicate = NSPredicate(format: "label MATCHES 'Welcome to the My Heart Counts(\\n| )Cardiovascular Health Study'")
         XCTAssert(staticTexts.element(matching: predicate).waitForExistence(timeout: 2))
         //XCTAssert(staticTexts["Welcome to the My Heart Counts\nCardiovascular Health Study"].waitForExistence(timeout: 2))
         buttons["Continue"].tap()

--- a/MyHeartCountsUITests/AOnboardingTests.swift
+++ b/MyHeartCountsUITests/AOnboardingTests.swift
@@ -58,7 +58,6 @@ extension XCUIApplication {
     private func navigateWelcome() {
         let predicate = NSPredicate(format: "label MATCHES 'Welcome to the My Heart Counts(\\n| )Cardiovascular Health Study'")
         XCTAssert(staticTexts.element(matching: predicate).waitForExistence(timeout: 2))
-        //XCTAssert(staticTexts["Welcome to the My Heart Counts\nCardiovascular Health Study"].waitForExistence(timeout: 2))
         buttons["Continue"].tap()
     }
     

--- a/MyHeartCountsWatchApp/Resources/InfoPlist.xcstrings
+++ b/MyHeartCountsWatchApp/Resources/InfoPlist.xcstrings
@@ -50,7 +50,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "MyHeart Counts crea datos de Salud relacionados con el ejercicio como parte de la realización de una Prueba de Caminata de Seis Minutos\n"
+            "value" : "MyHeart Counts crea datos de Salud relacionados con el ejercicio como parte de la realización de una Prueba de Caminata de Seis Minutos"
           }
         }
       }
@@ -68,7 +68,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "MyHeart Counts accede a algunos datos de Salud, como la frecuencia cardíaca, el conteo de pasos, etc., como parte de la realización de una Prueba de Caminata de Seis Minutos\n"
+            "value" : "MyHeart Counts accede a algunos datos de Salud, como la frecuencia cardíaca, el conteo de pasos, etc., como parte de la realización de una Prueba de Caminata de Seis Minutos"
           }
         }
       }

--- a/MyHeartCountsWatchApp/Resources/InfoPlist.xcstrings
+++ b/MyHeartCountsWatchApp/Resources/InfoPlist.xcstrings
@@ -1,0 +1,78 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "CFBundleDisplayName" : {
+      "comment" : "Bundle display name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "MyHeart Counts"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MyHeart Counts"
+          }
+        }
+      }
+    },
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "MyHeartCountsWatchApp"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MyHeartCountsWatchApp"
+          }
+        }
+      }
+    },
+    "NSHealthShareUsageDescription" : {
+      "comment" : "Privacy - Health Share Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "MyHeart Counts creates workout-related Health data as part of conducting a Six-Minute Walk Test"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MyHeart Counts crea datos de Salud relacionados con el ejercicio como parte de la realización de una Prueba de Caminata de Seis Minutos\n"
+          }
+        }
+      }
+    },
+    "NSHealthUpdateUsageDescription" : {
+      "comment" : "Privacy - Health Update Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "MyHeart Counts accesses some Health data, such as heart rate, step count, etc, as part of conducting a Six-Minute Walk Test"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MyHeart Counts accede a algunos datos de Salud, como la frecuencia cardíaca, el conteo de pasos, etc., como parte de la realización de una Prueba de Caminata de Seis Minutos\n"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/MyHeartCountsWatchApp/Resources/InfoPlist.xcstrings.license
+++ b/MyHeartCountsWatchApp/Resources/InfoPlist.xcstrings.license
@@ -1,0 +1,6 @@
+
+This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+
+SPDX-FileCopyrightText: 2025 Stanford University
+
+SPDX-License-Identifier: MIT

--- a/MyHeartCountsWatchApp/Resources/Localizable.xcstrings
+++ b/MyHeartCountsWatchApp/Resources/Localizable.xcstrings
@@ -16,7 +16,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abre la aplicación en tu iPhone para iniciar una Prueba de Caminata de Seis Minutos\n"
+            "value" : "Abre la aplicación en tu iPhone para iniciar una Prueba de Caminata de Seis Minutos"
           }
         }
       }
@@ -26,7 +26,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Consulta tu iPhone para más información.\n"
+            "value" : "Consulta tu iPhone para más información."
           }
         }
       }
@@ -36,7 +36,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prueba en curso\n"
+            "value" : "Prueba en curso"
           }
         }
       }

--- a/MyHeartCountsWatchApp/Resources/Localizable.xcstrings
+++ b/MyHeartCountsWatchApp/Resources/Localizable.xcstrings
@@ -1,0 +1,46 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "My Heart Counts" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "My Heart Counts"
+          }
+        }
+      }
+    },
+    "Open the app on your iPhone to start a\nSix-Minute Walk Test" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abre la aplicación en tu iPhone para iniciar una Prueba de Caminata de Seis Minutos\n"
+          }
+        }
+      }
+    },
+    "See your iPhone for more information." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consulta tu iPhone para más información.\n"
+          }
+        }
+      }
+    },
+    "Test ongoing" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prueba en curso\n"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/MyHeartCountsWatchApp/Resources/Localizable.xcstrings.license
+++ b/MyHeartCountsWatchApp/Resources/Localizable.xcstrings.license
@@ -1,0 +1,6 @@
+
+This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+
+SPDX-FileCopyrightText: 2025 Stanford University
+
+SPDX-License-Identifier: MIT

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ Contributions to this project are welcome. Please make sure to read the [contrib
 
 This project is licensed under the MIT License. See [Licenses](https://github.com/StanfordBDHG/MyHeartCounts-iOS/tree/main/LICENSES) for more information.
 
-![Stanford Biodesign Footer](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/FooterLight.png#gh-light-mode-only)
-![Stanford Biodesign Footer](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/FooterDark.png#gh-dark-mode-only)
+![Stanford Biodesign Footer](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-light.png#gh-light-mode-only)
+![Stanford Biodesign Footer](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-dark.png#gh-dark-mode-only)


### PR DESCRIPTION
# update translations; small HHD changes

## :recycle: Current situation & Problem
- we're missing translations for some spanish texts
- the HHD is displaying incorrect / technically-correct-but-intuitively-wrong time ranges in some cases


## :gear: Release Notes
- added a ton of spanish localizations
- the health dashboard, for the exercise minutes and step count metrics, now always uses the previous day's data to compute the score, as opposed to the current day. this is so that we can always present a "full" score instead telling people in the morning that their score is really bad, simply bc they haven't moved a lot yet.
- the health dashboard's "learn more" sections now can have multiple links; and they display a small preview of the host
- added ECG instructions (currently not yet triggered from anywhere)
- the time ranges and dates displayed in the health dashboard now should be more intuitive


## :books: Documentation
n/a

## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
