### PR TITLE
onboarding progress tracking

### DIFF
--- a/MyHeartCounts/Onboarding/OnboardingFlow.swift
+++ b/MyHeartCounts/Onboarding/OnboardingFlow.swift
@@ -51,52 +51,71 @@ private struct AppOnboardingFlow: View {
     var body: some View {
         ManagedNavigationStack(didComplete: $didCompleteOnboarding) { // swiftlint:disable:this closure_body_length
             Welcome()
+                .onboardingStep(.welcome)
             EligibilityScreening()
+                .onboardingStep(.eligibility)
             if !FeatureFlags.disableFirebase {
                 AccountOnboarding()
                     .injectingSpezi()
                     .navigationBarBackButtonHidden()
+                    .onboardingStep(.login)
             }
             OnboardingDisclaimerStep(
                 title: "ONBOARDING_DISCLAIMER_1_TITLE",
                 primaryText: "ONBOARDING_DISCLAIMER_1_PRIMARY_TEXT",
                 learnMoreText: "ONBOARDING_DISCLAIMER_1_LEARN_MORE_TEXT"
             )
+            .onboardingStep(.disclaimer1)
+            .injectingSpezi()
             OnboardingDisclaimerStep(
                 title: "ONBOARDING_DISCLAIMER_2_TITLE",
                 primaryText: "ONBOARDING_DISCLAIMER_2_PRIMARY_TEXT",
                 learnMoreText: "ONBOARDING_DISCLAIMER_2_LEARN_MORE_TEXT"
             )
+            .onboardingStep(.disclaimer2)
+            .injectingSpezi()
             OnboardingDisclaimerStep(
                 title: "ONBOARDING_DISCLAIMER_3_TITLE",
                 primaryText: "ONBOARDING_DISCLAIMER_3_PRIMARY_TEXT",
                 learnMoreText: "ONBOARDING_DISCLAIMER_3_LEARN_MORE_TEXT"
             )
+            .onboardingStep(.disclaimer3)
+            .injectingSpezi()
             OnboardingDisclaimerStep(
                 title: "ONBOARDING_DISCLAIMER_4_TITLE",
                 primaryText: "ONBOARDING_DISCLAIMER_4_PRIMARY_TEXT",
                 learnMoreText: "ONBOARDING_DISCLAIMER_4_LEARN_MORE_TEXT"
             )
+            .onboardingStep(.disclaimer4)
+            .injectingSpezi()
             ComprehensionScreening()
+                .onboardingStep(.comprehension)
+                .injectingSpezi()
             #if !(targetEnvironment(simulator) && (arch(i386) || arch(x86_64)))
             Consent()
+                .onboardingStep(.consent)
                 .injectingSpezi()
                 .navigationStepIdentifier("Consent")
             #endif
             if HKHealthStore.isHealthDataAvailable() {
                 // IDEA instead of having this in an if, we should probably have a full-screen "you can't participate" thing if the user doesn't have HealthKit?
                 HealthKitPermissions()
+                    .onboardingStep(.healthAccess)
                     .injectingSpezi()
             }
             if !localNotificationAuthorization {
                 NotificationPermissions()
+                    .onboardingStep(.notifications)
                     .injectingSpezi()
             }
             DemographicsStep()
+                .onboardingStep(.demographics)
                 .injectingSpezi()
             FinalEnrollmentStep()
+                .onboardingStep(.finalStep)
                 .injectingSpezi()
         }
+        .environment(\.isInOnboardingFlow, true)
         .environment(onboardingData)
         .interactiveDismissDisabled(!didCompleteOnboarding)
         .onChange(of: scenePhase, initial: true) {
@@ -123,4 +142,21 @@ private struct DemographicsStep: View {
             .listRowInsets(.zero)
         }
     }
+}
+
+
+extension OnboardingStep {
+    static let welcome = Self(rawValue: "welcome")
+    static let eligibility = Self(rawValue: "eligibility")
+    static let login = Self(rawValue: "login")
+    static let disclaimer1 = Self(rawValue: "disclaimer1")
+    static let disclaimer2 = Self(rawValue: "disclaimer2")
+    static let disclaimer3 = Self(rawValue: "disclaimer3")
+    static let disclaimer4 = Self(rawValue: "disclaimer4")
+    static let comprehension = Self(rawValue: "comprehension")
+    static let consent = Self(rawValue: "consent")
+    static let healthAccess = Self(rawValue: "healthAccess")
+    static let notifications = Self(rawValue: "notifications")
+    static let demographics = Self(rawValue: "demographics")
+    static let finalStep = Self(rawValue: "finalStep")
 }

--- a/MyHeartCounts/Onboarding/ProgressTracking.swift
+++ b/MyHeartCounts/Onboarding/ProgressTracking.swift
@@ -1,0 +1,77 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import Spezi
+import SpeziAccount
+import SwiftUI
+
+
+struct OnboardingStep: RawRepresentableAccountKey {
+    let rawValue: String
+    
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+
+private struct OnboardingStepModifier: ViewModifier {
+    // swiftlint:disable attributes
+    @Environment(\.isInOnboardingFlow) private var isInOnboarding
+    @Environment(Account.self) private var account: Account?
+    // swiftlint:enable attributes
+    
+    let step: OnboardingStep
+    
+    func body(content: Content) -> some View {
+        content.task {
+            guard isInOnboarding, let account else {
+                print("Skipping onboarding progress report", isInOnboarding, self.account)
+                return
+            }
+            do {
+                var details = AccountDetails()
+                details.mostRecentOnboardingStep = step
+                let modifications = try AccountModifications(modifiedDetails: details)
+                try await account.accountService.updateAccountDetails(modifications)
+            } catch {
+                print("Error updating most recent onboarding step: \(error)")
+            }
+        }
+    }
+}
+
+
+extension AccountDetails {
+    @AccountKey(
+        id: "mostRecentOnboardingStep",
+        name: "",
+        category: .other,
+        options: .mutable,
+        as: OnboardingStep.self,
+        initial: .default(.init(rawValue: ""))
+    )
+    var mostRecentOnboardingStep: OnboardingStep?
+}
+
+
+@KeyEntry(\.mostRecentOnboardingStep)
+extension AccountKeys {}
+
+
+extension EnvironmentValues {
+    @Entry var isInOnboardingFlow: Bool = false
+}
+
+
+extension View {
+    func onboardingStep(_ step: OnboardingStep) -> some View {
+        self.modifier(OnboardingStepModifier(step: step))
+    }
+}


### PR DESCRIPTION
# onboarding progress tracking

## :recycle: Current situation & Problem
this PR adds a very simple onboarding progress tracking system, whereby we write the most-recently presented onboarding step into a key in the user collection. the idea here is figuring out where, if at all, we lose most participants during the onboarding / where people get stuck.

fixes #50 


## :gear: Release Notes
- added onboarding progress tracking


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
