### PR TITLE
fix oversight in HHD

### DIFF
--- a/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
+++ b/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
@@ -184,11 +184,7 @@ struct HeartHealthDashboard: View {
                     .foregroundStyle(.secondary)
             }
         } onTap: {
-            if true {
-                addNewSample(for: scoreKeyPath)
-            } else {
-                scoreResultToExplain = .init(keyPath: scoreKeyPath, result: score)
-            }
+            scoreResultToExplain = .init(keyPath: scoreKeyPath, result: score)
         }
     }
     


### PR DESCRIPTION
# fix oversight in HHD

## :recycle: Current situation & Problem
re-enables HHD functionality


## :gear: Release Notes
- fixed: selecting a metric in the health dashboard would always open the data entry sheet, instead of opening the sheet for the metric.


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
