### PR TITLE
Add TestFlight Release Group for Beta Testing

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -203,23 +203,36 @@ platform :ios do
     commit = last_git_commit
     
     if environment == "production"
-      deliver(
+      # For our 4.0 beta releases, we currently only use TestFlight in a larger release group.
+      # deliver(
+      #   app_identifier: appidentifier,
+      #   release_notes: {
+      #     'en-US' => releasenotes
+      #   },
+      #   submit_for_review: true,
+      #   force: true,
+      #   reject_if_possible: true,
+      #   automatic_release: true,
+      #   precheck_include_in_app_purchases: false,
+      # )
+      upload_to_testflight(
         app_identifier: appidentifier,
-        release_notes: {
-          'en-US' => releasenotes
-        },
-        submit_for_review: true,
-        force: true,
-        reject_if_possible: true,
-        automatic_release: true,
-        precheck_include_in_app_purchases: false,
+        distribute_external: true,
+        reject_build_waiting_for_review: true,
+        expire_previous_builds: false,
+        groups: [
+          "Release Testing"
+        ],
+        submit_beta_review: true,
+        notify_external_testers: true,
+        changelog: releasenotes
       )
     else
       upload_to_testflight(
         app_identifier: appidentifier,
         distribute_external: true,
         reject_build_waiting_for_review: true,
-        expire_previous_builds: true,
+        expire_previous_builds: false, # Change to true, once we make App Store releases on production deployments.
         groups: [
           "External Testers"
         ],


### PR DESCRIPTION
# Add TestFlight Release Group for Beta Testing

## :gear: Release Notes
- Add TestFlight Release Group for Beta Testing

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
