### PR TITLE
encode enrollment info into FHIR observations

### DIFF
--- a/MyHeartCounts/Account/AccountSheet.swift
+++ b/MyHeartCounts/Account/AccountSheet.swift
@@ -225,7 +225,7 @@ extension AccountSheet {
                         Section {
                             let bundle = Bundle.main
                             LabeledContent("Version" as String, value: bundle.appVersion)
-                            LabeledContent("Build" as String, value: bundle.appBuildNumber ?? -1, format: .number)
+                            LabeledContent("Build" as String, value: bundle.appBuildNumber?.description ?? "n/a")
                         }
                         Section {
                             LabeledContent("Study Revision" as String, value: enrollments.first?.studyRevision.description ?? "n/a")

--- a/MyHeartCounts/MyHeartCountsStandard+CurrentEnrollmentInfo.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+CurrentEnrollmentInfo.swift
@@ -1,0 +1,42 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziFoundation
+import SpeziStudy
+
+
+extension MyHeartCountsStandard {
+    struct CurrentEnrollmentInfo: Sendable {
+        let studyId: String
+        let studyRevision: UInt
+    }
+    
+    private static let lock = RWLock()
+    nonisolated(unsafe) private static var _currentEnrollmentInfo: CurrentEnrollmentInfo?
+    
+    static var currentEnrollmentInfo: CurrentEnrollmentInfo? {
+        lock.withReadLock {
+            _currentEnrollmentInfo
+        }
+    }
+    
+    
+    @MainActor
+    static func _updateCurrentEnrollmentInfo(_ studyManager: StudyManager) { // swiftlint:disable:this identifier_name
+        lock.withWriteLock {
+            guard let enrollment = studyManager.studyEnrollments.first else {
+                _currentEnrollmentInfo = nil
+                return
+            }
+            _currentEnrollmentInfo = .init(
+                studyId: enrollment.studyId.uuidString,
+                studyRevision: enrollment.studyRevision
+            )
+        }
+    }
+}

--- a/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
@@ -285,7 +285,7 @@ extension FHIRExtensionUrls {
     // SAFETY: this is in fact safe, since the FHIRPrimitive's `extension` property is empty.
     // As a result, the actual instance doesn't contain any mutable state, and since this is a let,
     // it also never can be mutated to contain any.
-    /// Url of a FHIR Extension containing the user's time zone when uploading a FHIR `Observation`.
+    /// Url of a FHIR Extension containing the user's enrollment info uploading a FHIR `Observation`.
     nonisolated(unsafe) static let mhcStudyEnrollmentInfo: ModelsR4.FHIRPrimitive<_> = "https://myheartcounts.stanford.edu/fhir/StructureDefinition/study-enrollment".asFHIRURIPrimitive()!
     // swiftlint:disable:previous force_unwrapping
 }

--- a/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
@@ -103,6 +103,11 @@ extension MyHeartCountsStandard: HealthKitConstraint {
 
 
 extension MyHeartCountsStandard {
+    // NOTE: This is in fact concurrency-safe; we're just missing a `FHIRExtensionBuilderProtocol: Sendable` requirement in HKoF.
+    nonisolated(unsafe) static let defaultHealthObservationFHIRExtensions: [any FHIRExtensionBuilderProtocol] = [
+        .sampleUploadTimeZone, .mhcStudyRevision
+    ]
+    
     func uploadHealthObservation(
         _ observation: some HealthObservation & Sendable,
         postprocessResource: @Sendable (FHIRResource) throws -> Void = { _ in }
@@ -134,7 +139,7 @@ extension MyHeartCountsStandard {
                     voltageMeasurements: voltages.map { (time: $0.timeOffset, value: $0.voltage) },
                     withMapping: .default,
                     issuedDate: issuedDate,
-                    extensions: [.sampleUploadTimeZone]
+                    extensions: Self.defaultHealthObservationFHIRExtensions
                 )
                 try postprocessResource(FHIRResource(observation))
                 return AnyEncodable(observation)
@@ -154,7 +159,11 @@ extension MyHeartCountsStandard {
                 try postprocessResource(resource)
                 return AnyEncodable(resource)
             default:
-                let resource = try observation.resource(withMapping: .default, issuedDate: issuedDate, extensions: [.sampleUploadTimeZone])
+                let resource = try observation.resource(
+                    withMapping: .default,
+                    issuedDate: issuedDate,
+                    extensions: Self.defaultHealthObservationFHIRExtensions
+                )
                 try postprocessResource(FHIRResource(resource.get()))
                 return AnyEncodable(resource)
             }
@@ -272,6 +281,13 @@ extension FHIRExtensionUrls {
     /// Url of a FHIR Extension containing the user's time zone when uploading a FHIR `Observation`.
     nonisolated(unsafe) static let sampleUploadTimeZone: ModelsR4.FHIRPrimitive<_> = "https://bdh.stanford.edu/fhir/defs/sampleUploadTimeZone".asFHIRURIPrimitive()!
     // swiftlint:disable:previous force_unwrapping
+    
+    // SAFETY: this is in fact safe, since the FHIRPrimitive's `extension` property is empty.
+    // As a result, the actual instance doesn't contain any mutable state, and since this is a let,
+    // it also never can be mutated to contain any.
+    /// Url of a FHIR Extension containing the user's time zone when uploading a FHIR `Observation`.
+    nonisolated(unsafe) static let mhcStudyEnrollmentInfo: ModelsR4.FHIRPrimitive<_> = "https://myheartcounts.stanford.edu/fhir/StructureDefinition/study-enrollment".asFHIRURIPrimitive()!
+    // swiftlint:disable:previous force_unwrapping
 }
 
 extension FHIRExtensionBuilderProtocol where Self == FHIRExtensionBuilder<Void> {
@@ -281,6 +297,28 @@ extension FHIRExtensionBuilderProtocol where Self == FHIRExtensionBuilder<Void> 
                 url: FHIRExtensionUrls.sampleUploadTimeZone,
                 value: .string(TimeZone.current.identifier.asFHIRStringPrimitive())
             )
+            observation.appendExtension(ext, replaceAllExistingWithSameUrl: true)
+        }
+    }
+    
+    
+    static var mhcStudyRevision: Self {
+        .init { observation in
+            guard let enrollmentInfo = MyHeartCountsStandard.currentEnrollmentInfo else {
+                return
+            }
+            let extUrl = FHIRExtensionUrls.mhcStudyEnrollmentInfo
+            let ext = Extension(url: extUrl)
+            ext.extension = [
+                Extension(
+                    url: extUrl.appending(component: "study-id"),
+                    value: .string(enrollmentInfo.studyId.asFHIRStringPrimitive())
+                ),
+                Extension(
+                    url: extUrl.appending(component: "study-revision"),
+                    value: .integer(Int(enrollmentInfo.studyRevision).asFHIRIntegerPrimitive())
+                )
+            ]
             observation.appendExtension(ext, replaceAllExistingWithSameUrl: true)
         }
     }

--- a/MyHeartCounts/MyHeartCountsStandard.swift
+++ b/MyHeartCounts/MyHeartCountsStandard.swift
@@ -79,13 +79,21 @@ actor MyHeartCountsStandard: Standard, EnvironmentAccessible, AccountNotifyConst
     }
     
     func updateStudyDefinition() async {
-        guard let studyManager, let studyBundle = try? await studyLoader.update() else {
+        guard let studyManager else {
+            return
+        }
+        defer {
+            // we still want this to happen if the study bundle loading below failed
+            Swift::Task {
+                await Self._updateCurrentEnrollmentInfo(studyManager)
+            }
+        }
+        guard let studyBundle = try? await studyLoader.update() else {
             return
         }
         logger.notice("Informing StudyManager about v\(studyBundle.studyDefinition.studyRevision) of MHC studyBundle")
         do {
             try await studyManager.informAboutStudies([studyBundle])
-            await Self._updateCurrentEnrollmentInfo(studyManager)
         } catch {
             logger.error("\(error)")
         }

--- a/MyHeartCounts/MyHeartCountsStandard.swift
+++ b/MyHeartCounts/MyHeartCountsStandard.swift
@@ -84,7 +84,7 @@ actor MyHeartCountsStandard: Standard, EnvironmentAccessible, AccountNotifyConst
         }
         defer {
             // we still want this to happen if the study bundle loading below failed
-            Swift::Task {
+            _Concurrency.Task {
                 await Self._updateCurrentEnrollmentInfo(studyManager)
             }
         }

--- a/MyHeartCounts/MyHeartCountsStandard.swift
+++ b/MyHeartCounts/MyHeartCountsStandard.swift
@@ -85,6 +85,7 @@ actor MyHeartCountsStandard: Standard, EnvironmentAccessible, AccountNotifyConst
         logger.notice("Informing StudyManager about v\(studyBundle.studyDefinition.studyRevision) of MHC studyBundle")
         do {
             try await studyManager.informAboutStudies([studyBundle])
+            await Self._updateCurrentEnrollmentInfo(studyManager)
         } catch {
             logger.error("\(error)")
         }
@@ -116,6 +117,7 @@ actor MyHeartCountsStandard: Standard, EnvironmentAccessible, AccountNotifyConst
             _Concurrency.Task(priority: .background) {
                 historicalUploadManager.startAutomaticExportingIfNeeded()
             }
+            await Self._updateCurrentEnrollmentInfo(studyManager)
         } catch StudyManager.StudyEnrollmentError.alreadyEnrolledInNewerStudyRevision {
             // should be unreachable, but we'll handle this as a non-error just to be safe.
         } catch {

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+Base.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+Base.swift
@@ -78,7 +78,9 @@ extension MHCSensorSampleUploadStrategy {
         
         observation.addMHCAppAsSource()
         try observation.apply(.sensorKitSourceDevice, input: deviceInfo)
-        try observation.apply(.sampleUploadTimeZone)
+        for builder in MyHeartCountsStandard.defaultHealthObservationFHIRExtensions {
+            try builder.apply(typeErasedInput: self, to: observation)
+        }
         try postprocessObservation(observation)
         
         let sensorCollection = try await standard.firebaseConfiguration.userDocumentReference


### PR DESCRIPTION
# encode enrollment info into FHIR observations

## :gear: Release Notes
- new: FHIR observations now include metadata for the specific study id and revision that was active in the app when the observation was collected

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health data uploads now include study enrollment ID and revision metadata.
  * Enrollment info is refreshed promptly after enrollment so uploads use current study details.

* **Bug Fixes**
  * About screen build number now shows "n/a" when unavailable instead of "-1".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->