### PR TITLE
update dependencies to fix FHIRModels version at <0.9.0

### DIFF
--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1362,8 +1362,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziScheduler.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.17;
+				branch = "lukas/update-deps";
+				kind = branch;
 			};
 		};
 		804D89382EF4C0030037E431 /* XCRemoteSwiftPackageReference "SpeziAccount" */ = {

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1259,7 +1259,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/HealthKitOnFHIR.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.1;
+				minimumVersion = 1.2.2;
 			};
 		};
 		2FE5DC8229EDD934004B9AB4 /* XCRemoteSwiftPackageReference "SpeziQuestionnaire" */ = {
@@ -1267,7 +1267,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziQuestionnaire.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.4;
+				minimumVersion = 1.3.1;
 			};
 		};
 		2FE5DC9029EDD9C3004B9AB4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
@@ -1450,8 +1450,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/FHIRModels.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.0;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.8.0;
 			};
 		};
 		80BE064E2DCF3A2D00171114 /* XCRemoteSwiftPackageReference "swift-package-list" */ = {
@@ -1467,7 +1467,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/ResearchKitOnFHIR.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.5;
+				minimumVersion = 2.0.10;
 			};
 		};
 		80D596DA2F8303720029318F /* XCRemoteSwiftPackageReference "SpeziSensorKit" */ = {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a10b03c6d496f6fa617a0da345da3a7850f5f314ab5fece5c814f4983375808b",
+  "originHash" : "569f51b828362980428aeaac455244fe26bdb834cea9188f0af2397ceb179d65",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR.git",
       "state" : {
-        "revision" : "f866f864ac85cc8d0cdba49772d42ae077361f41",
-        "version" : "1.2.1"
+        "revision" : "acef83d55f6be6e1ef384d2c4bab2a5450979b32",
+        "version" : "1.2.2"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/ResearchKitOnFHIR.git",
       "state" : {
-        "revision" : "dc3e35d55e5c0acc0059c5f939535de230fdbd99",
-        "version" : "2.0.7"
+        "revision" : "56622e4cc17f2d640aae5e518f963a0ea7fb08e9",
+        "version" : "2.0.10"
       }
     },
     {
@@ -294,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziQuestionnaire.git",
       "state" : {
-        "revision" : "6110a9ec1be8fc35caf9b7aa20b7cf570e1a8ffb",
-        "version" : "1.2.4"
+        "revision" : "155a523b463b00a5cd0296af1e34def558ec763c",
+        "version" : "1.3.1"
       }
     },
     {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "569f51b828362980428aeaac455244fe26bdb834cea9188f0af2397ceb179d65",
+  "originHash" : "984c7c02e1a7a67274db93ee59506a9be0502ee82253206861184eeec6073561",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "674d9a7ee9858207181a3dd0b42c77298c6fb71b",
-        "version" : "12.8.0"
+        "revision" : "d47760f97a853808be6a045d278fbd12abf546b6",
+        "version" : "12.12.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "35b601a60fbbea2de3ea461f604deaaa4d8bbd0c",
-        "version" : "3.2.0"
+        "revision" : "23fa6970874ec8f3ac0039b3778ca8d6545d50ee",
+        "version" : "3.4.2"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "2ffd220823f3716904733162e9ae685545c276d1",
-        "version" : "12.8.0"
+        "revision" : "1657f705bc70255ff9d66dfcc697a85db164998f",
+        "version" : "12.11.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "fb7f2740b1570d2f7599c6bb9531bf4fad6974b7",
-        "version" : "5.0.0"
+        "revision" : "0be208810d2e8b90fcd2464d1816723b47819fe7",
+        "version" : "5.2.0"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/marmelroy/PhoneNumberKit",
       "state" : {
-        "revision" : "16bb5d46b82540280c5aab8976a94d8a9cda8135",
-        "version" : "4.2.2"
+        "revision" : "c15542f373a8593fc0cbeac443b0efb2cea4aff0",
+        "version" : "4.2.10"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziConsent.git",
       "state" : {
-        "revision" : "831d43671bbfc5a3d0380f7adf2584b06736fa2e",
-        "version" : "0.1.4"
+        "revision" : "8c37a69bb8bc7884f36831015652513c2fb87241",
+        "version" : "0.1.5"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziLicense.git",
       "state" : {
-        "revision" : "42bd5113d12f6c6b9dff9fe0123afcf2d2154f15",
-        "version" : "1.0.0"
+        "revision" : "f67c89f078f3e1e94e67fc673187d387b5aff683",
+        "version" : "1.1.0"
       }
     },
     {
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziScheduler.git",
       "state" : {
-        "revision" : "97128f603ad472bb34b5d355403455e12d6bddab",
-        "version" : "1.2.19"
+        "branch" : "lukas/update-deps",
+        "revision" : "620764468d73083bf00dc9a36af2b5cb06aec91c"
       }
     },
     {
@@ -348,8 +348,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "392dd6058624d9f6c5b4c769d165ddd8c7293394",
-        "version" : "0.15.4"
+        "revision" : "964c300fb0736699ce945c9edb56ecd62eba27a3",
+        "version" : "0.16.0"
       }
     },
     {
@@ -364,10 +364,10 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
@@ -402,8 +402,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
       }
     },
     {
@@ -411,8 +411,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "8c0f217f01000dd30f60d6e536569ad4e74291f9",
+        "version" : "1.11.0"
       }
     },
     {
@@ -429,8 +429,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "233f61bc2cfbb22d0edeb2594da27a20d2ce514e",
-        "version" : "2.93.0"
+        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
+        "version" : "2.97.1"
       }
     },
     {
@@ -447,8 +447,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FelixHerrmann/swift-package-list.git",
       "state" : {
-        "revision" : "c428a73b41f2d41d68cc333a7b0d2f25c788530c",
-        "version" : "4.9.0"
+        "revision" : "14f7e7de03182873d8c23cab4c8bbf0d9d46cad4",
+        "version" : "4.10.0"
       }
     },
     {
@@ -470,21 +470,12 @@
       }
     },
     {
-      "identity" : "swift-toolchain-sqlite",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-toolchain-sqlite",
-      "state" : {
-        "revision" : "b626d3002773b1a1304166643e7f118f724b2132",
-        "version" : "1.0.4"
-      }
-    },
-    {
       "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins.git",
       "state" : {
-        "revision" : "707f7face5524fe918f82dd39c5c80cb3e591a44",
-        "version" : "0.63.0"
+        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
+        "version" : "0.63.2"
       }
     },
     {
@@ -492,8 +483,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/ThreadLocal.git",
       "state" : {
-        "revision" : "16704d12f51abdd44c1f3c09bf28e619e4d789b2",
-        "version" : "0.1.2"
+        "revision" : "44d3c09da5fbdba0cdb50cb84781dc7d35659887",
+        "version" : "0.1.3"
       }
     },
     {
@@ -510,8 +501,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTestExtensions.git",
       "state" : {
-        "revision" : "5f4b9670acfac68ed55a2d6462d716a2bcdc2261",
-        "version" : "1.2.2"
+        "revision" : "d860cb6fde3ff5a0fb65f06575f1f8cd7f8a5fb5",
+        "version" : "1.2.6"
       }
     },
     {

--- a/MyHeartCountsShared/Package.swift
+++ b/MyHeartCountsShared/Package.swift
@@ -21,7 +21,6 @@ var packageDeps: [Package.Dependency] = [
 #if !os(Linux)
 packageDeps += [
     .package(url: "https://github.com/StanfordSpezi/SpeziStudy.git", from: "0.1.20"),
-    .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.4"), // not actually used but we need to force the version until we update SpeziStudy
     .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols.git", from: "7.0.0")
 ]
 #endif


### PR DESCRIPTION
# update dependencies

## :recycle: Current situation & Problem
update dependencies to fix FHIRModels version at <0.9.0, and fix a compilation issue with SpeziScheduler (bc of its SQLite.swift dependency)


## :gear: Release Notes
- internal updates


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
