### PR TITLE
data persistence changes, part 1

### DIFF
--- a/MyHeartCounts/Heart Health Dashboard/QuantitySample.swift
+++ b/MyHeartCounts/Heart Health Dashboard/QuantitySample.swift
@@ -69,7 +69,6 @@ enum MHCSampleType: Hashable, Identifiable, Sendable {
 
 
 extension MHCSampleType {
-    private static let allKnownHealthKitIdentifiers: Set<String> = HKObjectType.allKnownObjectTypes.mapIntoSet(\.identifier)
     private static let sampleTypeProxyByIdentifier: [String: SampleTypeProxy] = HKObjectType.allKnownObjectTypes.reduce(into: [:]) { result, type in
         if let sampleType = type.sampleType, let proxy = SampleTypeProxy(_ifPossible: sampleType) {
             result[type.identifier] = proxy

--- a/MyHeartCounts/Heart Health Dashboard/QuantitySample.swift
+++ b/MyHeartCounts/Heart Health Dashboard/QuantitySample.swift
@@ -68,6 +68,27 @@ enum MHCSampleType: Hashable, Identifiable, Sendable {
 }
 
 
+extension MHCSampleType {
+    private static let allKnownHealthKitIdentifiers: Set<String> = HKObjectType.allKnownObjectTypes.mapIntoSet(\.identifier)
+    private static let sampleTypeProxyByIdentifier: [String: SampleTypeProxy] = HKObjectType.allKnownObjectTypes.reduce(into: [:]) { result, type in
+        if let sampleType = type.sampleType, let proxy = SampleTypeProxy(_ifPossible: sampleType) {
+            result[type.identifier] = proxy
+        }
+    }
+    
+    /// Attempts to create an `MHCSampleType` from a raw identifier string.
+    init?(sampleTypeIdentifier identifier: String) {
+        if let custom = CustomQuantitySampleType(identifier: identifier) {
+            self = .custom(custom)
+        } else if let proxy = Self.sampleTypeProxyByIdentifier[identifier] {
+            self = .healthKit(proxy)
+        } else {
+            return nil
+        }
+    }
+}
+
+
 struct CustomQuantitySampleType: Hashable, Identifiable, Sendable {
     let id: String
     let displayTitle: LocalizedStringResource

--- a/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
@@ -104,14 +104,33 @@ extension MyHeartCountsStandard: HealthKitConstraint {
 
 
 extension MyHeartCountsStandard {
+    private enum HealthObservationUploadStrategy {
+        case directFirestore
+        case firebaseStorage
+    }
+    
+    
     // NOTE: This is in fact concurrency-safe; we're just missing a `FHIRExtensionBuilderProtocol: Sendable` requirement in HKoF.
     nonisolated(unsafe) static let defaultHealthObservationFHIRExtensions: [any FHIRExtensionBuilderProtocol] = [
         .sampleUploadTimeZone, .mhcStudyRevision
     ]
     
+    /// Determines how a health observation / resource should be persisted when uploading it to firebase.
+    private static func uploadStrategy(forSampleType identifier: String) -> HealthObservationUploadStrategy {
+        if identifier == TimedWalkingTestResult.sampleTypeIdentifier {
+            return .directFirestore
+        }
+        return switch MHCSampleType(sampleTypeIdentifier: identifier) {
+        case nil, .healthKit:
+            .firebaseStorage
+        case .custom:
+            .directFirestore
+        }
+    }
+    
     func uploadHealthObservation(
         _ observation: some HealthObservation & Sendable,
-        postprocessResource: @Sendable (FHIRResource) throws -> Void = { _ in }
+        postprocessResource: @escaping @Sendable (FHIRResource) throws -> Void = { _ in }
     ) async throws {
         try await uploadHealthObservations(
             CollectionOfOne(observation),
@@ -120,12 +139,24 @@ extension MyHeartCountsStandard {
         )
     }
     
-    func uploadHealthObservations( // swiftlint:disable:this function_body_length
+    func uploadHealthObservations( // swiftlint:disable:this function_body_length cyclomatic_complexity
         _ observations: consuming some Collection<some HealthObservation & Sendable> & Sendable,
         batchSize: Int = 100,
-        postprocessResource: @Sendable (FHIRResource) throws -> Void = { _ in }
+        postprocessResource: @escaping @Sendable (FHIRResource) throws -> Void = { _ in }
     ) async throws {
         guard !observations.isEmpty, let sampleTypeIdentifier = observations.first?.sampleTypeIdentifier else {
+            return
+        }
+        guard observations.allSatisfy({ $0.sampleTypeIdentifier == sampleTypeIdentifier }) else {
+            // in the unlikely case of the caller passing in heterogeneous health observations, we process each sample type individually
+            try await withThrowingDiscardingTaskGroup { taskGroup in
+                let bySampleType = observations.grouped(by: \.sampleTypeIdentifier)
+                for (_, observations) in bySampleType {
+                    taskGroup.addTask {
+                        try await self.uploadHealthObservations(observations, batchSize: batchSize, postprocessResource: postprocessResource)
+                    }
+                }
+            }
             return
         }
         let issuedDate = FHIRPrimitive<ModelsR4.Instant>(try .init(date: .now))
@@ -169,12 +200,13 @@ extension MyHeartCountsStandard {
                 return AnyEncodable(resource)
             }
         }
-        let supportsZstdUpload = !HKClinicalTypeIdentifier.allKnownIdentifiers.contains(HKClinicalTypeIdentifier(rawValue: sampleTypeIdentifier))
-        if supportsZstdUpload && observations.count >= 100 && observations.allSatisfy({ $0.sampleTypeIdentifier == sampleTypeIdentifier }) {
+        let uploadStrategy = Self.uploadStrategy(forSampleType: sampleTypeIdentifier)
+        switch uploadStrategy {
+        case .firebaseStorage:
             let numObservations = observations.count
             logger.notice("Uploading \(numObservations) observations of type '\(sampleTypeIdentifier)' via zstd upload")
             let triggerDidUploadNotification = await showDebugWillUploadHealthDataUploadEventNotification(
-                for: .new(sampleTypeTitle: sampleTypeIdentifier, count: numObservations, uploadMode: .compressed)
+                for: .new(sampleTypeTitle: sampleTypeIdentifier, count: numObservations, uploadStrategy: uploadStrategy)
             )
             let resources: [AnyEncodable] = try await (consume observations).async.reduce(into: []) { resources, observation in
                 if let resource = try await turnIntoFHIRResource(observation) {
@@ -192,10 +224,10 @@ extension MyHeartCountsStandard {
                 try await managedFileUpload.upload(url, category: .liveHealthUpload)
                 await triggerDidUploadNotification()
             }
-        } else {
+        case .directFirestore:
             for chunk in (consume observations).chunks(ofCount: batchSize) {
                 let triggerDidUploadNotification = await showDebugWillUploadHealthDataUploadEventNotification(
-                    for: .new(sampleTypeTitle: sampleTypeIdentifier, count: chunk.count, uploadMode: .direct)
+                    for: .new(sampleTypeTitle: sampleTypeIdentifier, count: chunk.count, uploadStrategy: uploadStrategy)
                 )
                 let batch = Firestore.firestore().batch()
                 for observation in chunk {
@@ -234,13 +266,17 @@ extension MyHeartCountsStandard {
 
 extension MyHeartCountsStandard {
     private enum HealthDocumentChange {
-        case new(sampleTypeTitle: String, count: Int, uploadMode: UploadMode)
+        case new(sampleTypeTitle: String, count: Int, uploadStrategy: HealthObservationUploadStrategy)
         case deleted(sampleTypeTitle: String, count: Int)
     }
     
-    private enum UploadMode: String {
-        case direct
-        case compressed
+    private static func notificationLabel(for uploadStrategy: HealthObservationUploadStrategy) -> String {
+        switch uploadStrategy {
+        case .directFirestore:
+            "direct"
+        case .firebaseStorage:
+            "storage"
+        }
     }
     
     /// - returns: A closure that should be called upon completion of the uploads, and will replaces the "will upload" notifications with "did upload" notifications.
@@ -255,9 +291,9 @@ extension MyHeartCountsStandard {
             let notificationCenter = UNUserNotificationCenter.current()
             let content = UNMutableNotificationContent()
             switch change {
-            case let .new(sampleTypeTitle, count, uploadMode):
+            case let .new(sampleTypeTitle, count, uploadStrategy):
                 content.title = "\(stage) upload new health observations"
-                content.body = "\(count) new observations for \(sampleTypeTitle). mode: \(uploadMode.rawValue)"
+                content.body = "\(count) new observations for \(sampleTypeTitle). mode: \(Self.notificationLabel(for: uploadStrategy))"
             case let .deleted(sampleTypeTitle, count):
                 content.title = "\(stage) delete health observations"
                 content.body = "\(count) deleted observations for \(sampleTypeTitle)"

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+FHIR.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+FHIR.swift
@@ -11,6 +11,7 @@ import ModelsR4
 import SpeziSensorKit
 
 
+// periphery:ignore - retained for future use; live SensorKit upload uses ``UploadStrategyJSONFile``.
 /// An upload strategy that uploads each sample as a FHIR observation.
 struct UploadStrategyFHIRObservations<Sample: SensorKitSampleProtocol>: MHCSensorSampleUploadStrategy
 where Sample.SafeRepresentation: HealthObservation {

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+JSON.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+JSON.swift
@@ -1,0 +1,67 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import HealthKitOnFHIR
+import ModelsR4
+import MyHeartCountsShared
+import SpeziSensorKit
+
+
+/// An upload strategy that encodes a batch of samples as a JSON array of FHIR resources, uploads the file to firebase storage, and creates a corresponding FHIR Observation referencing the file.
+struct UploadStrategyJSONFile<Sample: SensorKitSampleProtocol>: MHCSensorSampleUploadStrategy
+where Sample.SafeRepresentation: HealthObservation {
+    func upload(
+        _ samples: some RandomAccessCollection<Sample.SafeRepresentation> & Sendable,
+        batchInfo: SensorKit.BatchInfo,
+        for sensor: Sensor<Sample>,
+        to standard: MyHeartCountsStandard,
+        activity: SensorKitDataFetcher.InProgressActivity
+    ) async throws {
+        guard let firstSample = samples.first else {
+            return
+        }
+        activity.updateMessage("Encoding FHIR resources to JSON")
+        let issuedDate = FHIRPrimitive<ModelsR4.Instant>(try .init(date: .now))
+        let resources: [AnyEncodable] = try samples.map { sample in
+            let resource = try sample.resource(
+                withMapping: .default,
+                issuedDate: issuedDate,
+                extensions: MyHeartCountsStandard.defaultHealthObservationFHIRExtensions
+            )
+            if case .observation(let observation) = resource {
+                try observation.apply(.sensorKitSourceDevice, input: batchInfo.device)
+            }
+            return AnyEncodable(resource)
+        }
+        let data = try JSONEncoder().encode(resources)
+        try await upload(
+            data: data,
+            fileExtension: "json",
+            for: sensor,
+            deviceInfo: batchInfo.device,
+            to: standard,
+            observationDocName: "\(batchInfo.timeRange.lowerBound.ISO8601Format())_\(batchInfo.timeRange.upperBound.ISO8601Format())",
+            activity: activity
+        ) { observation in
+            let (minDate, maxDate) = {
+                var minDate = firstSample.timeRange.lowerBound
+                var maxDate = firstSample.timeRange.upperBound
+                for sample in samples {
+                    minDate = min(minDate, sample.timeRange.lowerBound)
+                    maxDate = max(maxDate, sample.timeRange.upperBound)
+                }
+                return (minDate, maxDate)
+            }()
+            observation.effective = try .period(Period(
+                end: FHIRPrimitive(DateTime(date: maxDate)),
+                start: FHIRPrimitive(DateTime(date: minDate))
+            ))
+        }
+    }
+}

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher.swift
@@ -245,10 +245,10 @@ extension SensorKit {
             return []
         }
         return [
-            MHCSensorUploadDefinition(sensor: .visits, strategy: UploadStrategyFHIRObservations()),
-            MHCSensorUploadDefinition(sensor: .onWrist, strategy: UploadStrategyFHIRObservations()),
-            MHCSensorUploadDefinition(sensor: .deviceUsage, strategy: UploadStrategyFHIRObservations()),
-            MHCSensorUploadDefinition(sensor: .ecg, strategy: UploadStrategyFHIRObservations()),
+            MHCSensorUploadDefinition(sensor: .visits, strategy: UploadStrategyJSONFile()),
+            MHCSensorUploadDefinition(sensor: .onWrist, strategy: UploadStrategyJSONFile()),
+            MHCSensorUploadDefinition(sensor: .deviceUsage, strategy: UploadStrategyJSONFile()),
+            MHCSensorUploadDefinition(sensor: .ecg, strategy: UploadStrategyJSONFile()),
             MHCSensorUploadDefinition(sensor: .wristTemperature, strategy: UploadStrategyCSVFile2()),
             MHCSensorUploadDefinition(sensor: .heartRate, strategy: UploadStrategyCSVFile()),
             MHCSensorUploadDefinition(sensor: .pedometer, strategy: UploadStrategyCSVFile()),


### PR DESCRIPTION
# data persistence changes, part 1


## :gear: Release Notes
- data persistence now strongly prefers storage upload over firestore upload, allowing the backend to make a more informed decision (vs what the app could do) as to how each sample type should be handled.


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
