### PR TITLE
fix: "today's tasks" would include completed tasks from past days

### DIFF
--- a/MyHeartCounts/Upcoming Tasks Tab/MHCTodaysEventsQuery.swift
+++ b/MyHeartCounts/Upcoming Tasks Tab/MHCTodaysEventsQuery.swift
@@ -31,7 +31,15 @@ struct MHCTodaysEventsQuery: DynamicProperty {
             } else if event.occurrence.schedule.recurrence == nil {
                 // if the schedule is a one-off thing, we also always include it.
                 // this is intended to catch initial one-off study components that haven't been completed.
-                return true
+                // exception here is if the event is already completed, and the completion is outside of the primaryTimeRange.
+                // ie, we always show the one-off events if they are still open, and once they are completed we continue showing them until the end of the day.
+                if let completionDate = event.outcome?.completionDate {
+                    // show the event if it was completed recently (w/in the primaryTimeRange)
+                    return primaryTimeRange.contains(completionDate)
+                } else { // !event.isCompleted
+                    // always show yet-to-be-completed events
+                    return true
+                }
             } else {
                 return false
             }

--- a/MyHeartCountsUITests/TaskHandlingTests.swift
+++ b/MyHeartCountsUITests/TaskHandlingTests.swift
@@ -162,8 +162,9 @@ extension MHCTestCase {
         if alert.waitForExistence(timeout: timeout.timeInterval) {
             // wait a little longer. sometimes the "exists" above resolves to true while the alert is still being presented,
             // in which case the tap is a little too early and doesn't actually get registered.
-            sleep(for: .seconds(0.5))
-            alert.buttons["Allow"].tap()
+            let allowButton = alert.buttons["Allow"]
+            XCTAssert(allowButton.wait(for: \.isHittable, toEqual: true, timeout: 5))
+            allowButton.tap()
         }
     }
 }

--- a/MyHeartCountsUITests/TaskHandlingTests.swift
+++ b/MyHeartCountsUITests/TaskHandlingTests.swift
@@ -160,6 +160,9 @@ extension MHCTestCase {
         let app = XCUIApplication.springboard
         let alert = app.alerts.element(matching: "label LIKE %@", "“*” would like to access your Motion & Fitness activity.")
         if alert.waitForExistence(timeout: timeout.timeInterval) {
+            // wait a little longer. sometimes the "exists" above resolves to true while the alert is still being presented,
+            // in which case the tap is a little too early and doesn't actually get registered.
+            sleep(for: .seconds(0.5))
             alert.buttons["Allow"].tap()
         }
     }


### PR DESCRIPTION
# fix: "today's tasks" would include completed tasks from past days

## :recycle: Current situation & Problem
issue: the "Today's Tasks" list sometimes incorrectly includes already completed tasks from past days, if these tasks are identified as start-of-enrollment one-off events.


## :gear: Release Notes
- fixed: "Today's Tasks" list would incorrectly show completed tasks from past days


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upcoming task/event filtering so one-time events outside the main window are shown more accurately based on completion timing.
  * Enhanced the Motion & Fitness permission flow by waiting for the **Allow** button to be tappable before proceeding, making the prompt handling more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->