### PR TITLE
Link MHC License in License Information Tab

### DIFF
--- a/MyHeartCounts/Account/AccountSheet.swift
+++ b/MyHeartCounts/Account/AccountSheet.swift
@@ -8,6 +8,7 @@
 
 import FirebaseCore
 import FirebaseFunctions
+import MyHeartCountsShared
 import SFSafeSymbols
 import SpeziAccount
 import SpeziHealthKitBulkExport
@@ -101,7 +102,10 @@ struct AccountSheet: View {
                     .foregroundStyle(colorScheme.textLabelForegroundStyle)
             }
             NavigationLink {
-                ContributionsList(projectLicense: .mit)
+                ContributionsList(
+                    projectLicense: .mit,
+                    projectUrl: "https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/blob/main/LICENSE.md"
+                )
             } label: {
                 Label("License Information", systemSymbol: .buildingColumns)
                     .foregroundStyle(colorScheme.textLabelForegroundStyle)

--- a/MyHeartCounts/Account/AccountSheet.swift
+++ b/MyHeartCounts/Account/AccountSheet.swift
@@ -104,7 +104,7 @@ struct AccountSheet: View {
             NavigationLink {
                 ContributionsList(
                     projectLicense: .mit,
-                    projectUrl: "https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/blob/main/LICENSE.md"
+                    projectUrl: "https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/"
                 )
             } label: {
                 Label("License Information", systemSymbol: .buildingColumns)


### PR DESCRIPTION
This PR serves as a temporary fix/reminder to link the MHC license in the License Information Tab of the App.
The clean path would be a small upstream PR to [StanfordSpezi/SpeziLicense](https://github.com/StanfordSpezi/SpeziLicense) adding something like `projectLicenseText:` to `ContributionsList`. Will do this soon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The License Information section now includes a link to the project’s website, making it easier to view related project details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->