### PR TITLE
skip consent in onboarding if possible; test renewal

### DIFF
--- a/MyHeartCounts/Account/AccountSheet.swift
+++ b/MyHeartCounts/Account/AccountSheet.swift
@@ -70,6 +70,7 @@ struct AccountSheet: View {
                 }
             }
         }
+        .accessibilityIdentifier("MHC:AccountSheet")
     }
     
     @ViewBuilder private var accountSheetExtraContent: some View {
@@ -267,6 +268,7 @@ extension AccountSheet {
     private struct AboutRow: View {
         // swiftlint:disable attributes
         @Environment(Account.self) private var account
+        @Environment(StudyBundleLoader.self) private var studyBundleLoader
         // swiftlint:enable attributes
         @StudyManagerQuery private var enrollments: [StudyEnrollment]
         
@@ -283,6 +285,8 @@ extension AccountSheet {
             .onTapGesture(count: 5) {
                 showExtendedInfo = true
             }
+            .accessibilityElement()
+            .accessibilityIdentifier("MHC:AboutRow")
             .sheet(isPresented: $showExtendedInfo) {
                 NavigationStack {
                     Form {
@@ -292,20 +296,31 @@ extension AccountSheet {
                             LabeledContent("Build" as String, value: bundle.appBuildNumber?.description ?? "n/a")
                         }
                         Section {
-                            LabeledContent("Study Revision" as String, value: enrollments.first?.studyRevision.description ?? "n/a")
-                        }
-                        Section {
                             LabeledContent("Project ID" as String, value: FirebaseApp.app()?.options.projectID ?? "n/a")
                             LabeledContent("Account ID" as String, value: account.details?.accountId ?? "n/a")
                         }
+                        Section {
+                            LabeledContent("Study Revision (enrolled)" as String, value: enrollments.first?.studyRevision.description ?? "n/a")
+                            LabeledContent(
+                                "Study Revision (fetched)" as String,
+                                value: (try? studyBundleLoader.studyBundle?.get())?.studyDefinition.studyRevision.description ?? "n/a"
+                            )
+                            LabeledContent(
+                                "lastSignedConsentVersion" as String,
+                                value: account.details?.lastSignedConsentVersion?.description ?? "n/a"
+                            )
+                        }
                     }
+                    .navigationTitle("Extended Info" as String)
+                    .navigationBarTitleDisplayMode(.inline)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             DismissButton()
                         }
                     }
                 }
-                .presentationDetents([.medium])
+                .presentationDetents([.medium, .large])
+                .accessibilityIdentifier("MHC:AboutRow:ExtendedInfoSheet")
             }
         }
     }

--- a/MyHeartCounts/Modules/ConsentManager.swift
+++ b/MyHeartCounts/Modules/ConsentManager.swift
@@ -8,8 +8,11 @@
 
 import FirebaseStorage
 import Foundation
+import MyHeartCountsShared
+@_spi(APISupport) // dynamic module loading
 import Spezi
 import SpeziAccount
+import class SpeziConsent.ConsentDocument
 import SpeziFoundation
 import SpeziLocalization
 import SpeziStudy
@@ -17,14 +20,21 @@ import SwiftUI
 
 
 @Observable
-final class ConsentManager: Module, EnvironmentAccessible, @unchecked Sendable {
+@MainActor
+final class ConsentManager: Module, EnvironmentAccessible, Sendable {
     // swiftlint:disable attributes
+    @ObservationIgnored @Application(\.spezi) private var spezi
     @ObservationIgnored @Dependency(StudyBundleLoader.self) private var studyBundleLoader
     @ObservationIgnored @Dependency(Account.self) private var account: Account?
     @ObservationIgnored @Dependency(StudyManager.self) private var studyManager
     // swiftlint:enable attributes
     
-    @MainActor private(set) var needsToSignNewConsentVersion = false
+    @MainActor var pendingConsentDoc: ConsentDocument?
+    
+    
+    private var isInTestEnvSetup: Bool {
+        spezi.module(SetupTestEnvironment.self)?.isInSetup ?? false
+    }
     
     nonisolated init() {}
     
@@ -43,35 +53,93 @@ final class ConsentManager: Module, EnvironmentAccessible, @unchecked Sendable {
                 await self?.doUpdate()
             }
         }
-        guard LocalPreferencesStore.standard[.onboardingFlowComplete] else {
-            return
-        }
-        guard !needsToSignNewConsentVersion else {
+        guard LocalPreferencesStore.standard[.onboardingFlowComplete], !isInTestEnvSetup else {
+            // we never want this to trigger during the regular onboarding, as it could interfere with the flow there.
             return
         }
         guard let studyBundle else {
             return
         }
-        guard let accountDetails = account?.details else {
+        guard let doc = try? loadConsentDoc(from: studyBundle) else {
             return
         }
-        guard let consentFile = studyBundle.studyDefinition.metadata.consentFileRef,
+        if let shouldSign = try? shouldSign(doc.metadata) {
+            print("shouldSign? \(shouldSign)")
+            switch shouldSign {
+            case .no:
+                pendingConsentDoc = nil
+            case .yes(.signedOldVersion):
+                pendingConsentDoc = doc
+            case .yes(.neverSigned):
+                if LaunchOptions[.triggerConsentRenewalIfNeverSigned] {
+                    pendingConsentDoc = doc
+                } else {
+                    pendingConsentDoc = nil
+                }
+            }
+        }
+    }
+    
+    
+    func loadConsentDoc() async throws -> ConsentDocument {
+        // NOTE: we need to get the StudyBundle from the StudyBundleLoader, instead of the StudyManager,
+        // since the app won't necessarily be already enrolled at this point.
+        // (it is if this is a Consent renewal, but not during the initial onboarding...)
+        try loadConsentDoc(from: try await studyBundleLoader.update())
+    }
+    
+    func loadConsentDoc(from studyBundle: StudyBundle) throws -> ConsentDocument {
+        guard let fileRef = studyBundle.studyDefinition.metadata.consentFileRef,
               let consentText = studyBundle.consentText(
-                for: consentFile,
+                for: fileRef,
                 in: studyManager.preferredLocale,
                 using: .requirePerfectMatch,
                 fallbackLocale: studyManager.defaultLanguageFallbackLocale
-              ),
-              let consentVersion = (try? MarkdownDocument.Metadata(parsing: consentText))?.version else {
-                  return
+              ) else {
+            throw NSError(mhcErrorCode: .unspecified, localizedDescription: "Failed to load doc")
         }
-        if let lastSignedVersion = accountDetails.lastSignedConsentVersion.flatMap(Version.init) {
-            needsToSignNewConsentVersion = consentVersion.isGreaterThan(lastSignedVersion, upFrom: .minor)
+        return try ConsentDocument(
+            markdown: consentText,
+            initialName: account?.details?.name
+        )
+    }
+}
+
+
+extension ConsentManager {
+    private struct UnableToDetermineShouldSignStatusError: Error {}
+    
+    enum ShouldSignConsentResult {
+        case yes(YesReason)
+        case no // swiftlint:disable:this identifier_name
+        
+        enum YesReason {
+            case neverSigned
+            case signedOldVersion
+        }
+    }
+    
+    /// Determines if the user should be prompted to sign a specific consent document.
+    ///
+    /// - returns: a boolean indicating whether the user should be asked to sign the supplied consent version.
+    /// - throws: if the function was unable to determine the consent state.
+    ///     this will typically happen if the app is offline and the last-signed version cannot be determined, or if the input does not contain a valid version.
+    ///
+    /// - Note: If this function is unsure whether the user already signed the document, or signed a recent enough version of it, it will err on the side of caution and
+    ///     rather suggest the user be asked to re-sign the document, than not.
+    @MainActor
+    func shouldSign(_ documentMetadata: MarkdownDocument.Metadata) throws -> ShouldSignConsentResult {
+        guard let accountDetails = account?.details,
+              let docVersion = documentMetadata.version else {
+            throw UnableToDetermineShouldSignStatusError()
+        }
+        guard let lastSignedVersion = accountDetails.lastSignedConsentVersion.flatMap(Version.init) else {
+            return .yes(.neverSigned)
+        }
+        return if docVersion.isGreaterThan(lastSignedVersion, upFrom: .minor) {
+            .yes(.signedOldVersion)
         } else {
-            // we're unable to get the most recent signed, so we'll make the user re-sign it
-//            await MainActor.run {
-//                self.needsToSignNewConsentVersion = true
-//            }
+            .no
         }
     }
 }

--- a/MyHeartCounts/Modules/SetupTestEnvironment.swift
+++ b/MyHeartCounts/Modules/SetupTestEnvironment.swift
@@ -12,6 +12,7 @@ import MyHeartCountsShared
 import OSLog
 import Spezi
 import SpeziAccount
+import SpeziConsent
 import SpeziFirebaseAccount
 import SpeziFoundation
 import SpeziHealthKit
@@ -50,6 +51,7 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
     @ObservationIgnored @Dependency(BulkHealthExporter.self) private var bulkHealthExporter
     @ObservationIgnored @Dependency(ManagedFileUpload.self) private var fileUploader
     @ObservationIgnored @Dependency(LocalStorage.self) private var localStorage
+    @ObservationIgnored @Dependency(ConsentManager.self) private var consentManager: ConsentManager?
     @ObservationIgnored @Dependency(StudyManager.self) private var studyManager: StudyManager?
     // swiftlint:enable attributes
     
@@ -94,6 +96,15 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
         isInSetup = true
         defer {
             isInSetup = false
+            Task {
+                // It's important that this runs after isInSetup is cleared;
+                // otherwise eg the ConsentManager will see the new study bundle and run its renewal flow logic,
+                // but return early bc it sees that the test env setup is still ongoing.
+                // Run a bundle update, this will end up re-fetching the exact same bundle we already fetched above,
+                // but it'll also trigger all components in the app that observe the study bundle.
+                // (eg the ConsentManager, for the renewal flow.)
+                _ = try? await self.studyBundleLoader.update()
+            }
         }
         if config.resetExistingData {
             desc = "\(#function) will reset existing data"
@@ -137,14 +148,16 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
     }
     
     
-    private func loginAndEnroll(_ credentials: SetupTestEnvironmentConfig.Credentials) async throws {
+    private func loginAndEnroll( // swiftlint:disable:this function_body_length
+        _ credentials: SetupTestEnvironmentConfig.Credentials
+    ) async throws {
         logger.notice("Logging in and enrolling into Study using credentials \(String(describing: credentials))")
         // we set this immediately at the beginning, since the value will likely have been cleared in
         // the `resetExistingData()` call preceding this `loginAndEnroll()` call, and we don't want the
         // onboarding sheet covering the "Setting up Test Environment" full-screen thing.
         LocalPreferencesStore.standard[.onboardingFlowComplete] = true
-        guard let accountService, let account else {
-            logger.error("Unable to log in and enroll: no AccountService and/or Account!")
+        guard let accountService, let account, let consentManager else {
+            logger.error("Unable to log in and enroll: missing dependencies!")
             return
         }
         guard studyManager != nil else {
@@ -192,6 +205,26 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
             try await _Concurrency.Task.sleep(for: .seconds(1))
             try await clinicalRecordPermissions.askForAuthorization(askAgainIfCancelledPreviously: false)
         }
+        
+        if let newVersion = LaunchOptions[.overrideLastSignedConsentVersion] {
+            var newDetails = AccountDetails()
+            newDetails.lastSignedConsentVersion = newVersion.description
+            let modifications = try AccountModifications(modifiedDetails: newDetails)
+            try await accountService.updateAccountDetails(modifications)
+        } else {
+            // unless already present, we set the account's `lastSignedConsentVersion`; this otherwise would happen as part of the regular onboarding
+            if let details = account.details,
+               details.lastSignedConsentVersion == nil,
+               let consentDoc = try? consentManager.loadConsentDoc(from: studyBundle),
+               let consentVersion = consentDoc.metadata.version {
+                var newDetails = AccountDetails()
+                newDetails.lastSignedConsentVersion = consentVersion.description
+                newDetails.lastSignedConsentDate = Date()
+                let modifications = try AccountModifications(modifiedDetails: newDetails)
+                try await accountService.updateAccountDetails(modifications)
+            }
+        }
+        
         LocalPreferencesStore.standard[.onboardingFlowComplete] = true
         desc = "\(#function) DONE"
     }

--- a/MyHeartCounts/Modules/StudyBundleLoader.swift
+++ b/MyHeartCounts/Modules/StudyBundleLoader.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Algorithms
 import FirebaseCore
 import Foundation
 import MHCStudyDefinitionExporter
@@ -195,8 +196,12 @@ final class StudyBundleLoader: Module, Sendable {
     
     
     private func openDownloadedStudyBundle(at url: URL) async throws(LoadError) -> StudyBundle {
-        let tmpUrl = URL.temporaryDirectory.appending(component: UUID().uuidString).appendingPathExtension("\(StudyBundle.fileExtension).aar")
         let dstUrl = self.studyBundlesUrl.appendingPathComponent(UUID().uuidString, conformingTo: .speziStudyBundle)
+        guard url.studyBundleResourceType() == .archive else {
+            throw .unableToDecode(NSError(mhcErrorCode: .unspecified, localizedDescription: "Invalid file format"))
+        }
+        // Can we maybe elide the url -> tmpUrl copy here?(!)
+        let tmpUrl = URL.temporaryDirectory.appending(component: UUID().uuidString).appendingPathExtension("\(StudyBundle.fileExtension).aar")
         do {
             try fileManager.copyItem(at: url, to: tmpUrl, overwriteExisting: true)
             defer {
@@ -226,7 +231,21 @@ final class StudyBundleLoader: Module, Sendable {
     private func download(_ url: URL) async throws -> URL {
         logger.notice("will try to download '\(url.absoluteString)'")
         let session = URLSession(configuration: .ephemeral)
-        let (downloadUrl, response) = try await session.download(from: url)
+        let (downloadUrl, response): (URL, URLResponse)
+        do {
+            (downloadUrl, response) = try await session.download(from: url)
+        } catch {
+            if (error as NSError).code == NSURLErrorFileIsDirectory, url.isFileURL {
+                // we're given a package-style input, rather than an archive.
+                // we simply turn it into an archive, and pass that url on.
+                let dstUrl: URL = .temporaryDirectory
+                    .appending(component: UUID().uuidString).appendingPathExtension("\(StudyBundle.fileExtension).aar")
+                try fileManager.archiveDirectory(at: url, to: dstUrl)
+                return dstUrl
+            } else {
+                throw error
+            }
+        }
         logger.notice("did finish download of '\(url.lastPathComponent)'")
         guard let response = response as? HTTPURLResponse else {
             guard !url.isFileURL else {
@@ -278,5 +297,29 @@ final class StudyBundleLoader: Module, Sendable {
 extension StudyBundleLoader {
     private static func url(ofFile filename: String, inBucket bucketName: String) -> URL {
         "https://firebasestorage.googleapis.com/v0/b/\(bucketName)/o/public%2F\(filename)?alt=media"
+    }
+}
+
+
+extension URL {
+    fileprivate enum StudyBundleResourceType {
+        case archive
+        case package
+    }
+    
+    fileprivate func studyBundleResourceType() -> StudyBundleResourceType? {
+        guard let values = try? self.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey, .isPackageKey]) else {
+            return nil
+        }
+        if values.isRegularFile == true, hasExtension("spezistudybundle.aar") {
+            return .archive
+        } else if values.isDirectory == true, hasExtension("spezistudybundle") {
+            return .package
+        }
+        return nil
+    }
+    
+    private func hasExtension(_ ext: String) -> Bool {
+        lastPathComponent.ends(with: chain(".", ext))
     }
 }

--- a/MyHeartCounts/Onboarding/ComprehensionScreening.swift
+++ b/MyHeartCounts/Onboarding/ComprehensionScreening.swift
@@ -9,6 +9,7 @@
 // swiftlint:disable file_types_order discouraged_optional_boolean
 
 import Foundation
+import SpeziConsent
 import SpeziFoundation
 import SpeziOnboarding
 import SpeziViews
@@ -16,6 +17,8 @@ import SwiftUI
 
 
 struct ComprehensionScreening: View {
+    let consentDoc: ConsentDocument
+    
     var body: some View {
         SinglePageScreening(
             title: "COMPREHENSION_STEP_TITLE",
@@ -39,7 +42,11 @@ struct ComprehensionScreening: View {
             }
             return isTrue(\.seekHelpIfNotFeelingWell) && isTrue(\.studyParticipationIsVoluntary) && isTrue(\.canStopParticipatingAtAnyTime)
         } continue: { _, path in
-            path.nextStep()
+            path.append {
+                Consent(document: consentDoc)
+                    .onboardingStep(.consent)
+                    .injectingSpezi()
+            }
         }
     }
 }
@@ -75,7 +82,7 @@ private struct Question: ScreeningComponent {
 
 #Preview {
     ManagedNavigationStack {
-        ComprehensionScreening()
+        ComprehensionScreening(consentDoc: .previewDoc)
     }
     .environment(OnboardingDataCollection())
 }

--- a/MyHeartCounts/Onboarding/Consent.swift
+++ b/MyHeartCounts/Onboarding/Consent.swift
@@ -23,32 +23,27 @@ struct Consent: View {
     @Environment(OnboardingDataCollection.self) private var onboardingData: OnboardingDataCollection?
     @Environment(MyHeartCountsStandard.self) private var standard
     @Environment(Account.self) private var account
-    @Environment(StudyBundleLoader.self) private var studyLoader
     // NOTE: at this step, we aren't yet enrolled into the study,
     // so we can't access `studyManager.enrollments`, but we CAN access
     // `studyManager.preferredLocale`, since that has been set in a previous step.
     @Environment(StudyManager.self) private var studyManager
     // swiftlint:enable attributes
     
+    private let document: ConsentDocument
     private let continueAction: (@MainActor () -> Void)?
-    
-    @State private var consentDocument: ConsentDocument?
     @State private var viewState: ViewState = .idle
     
     var body: some View {
-        OnboardingConsentView(consentDocument: consentDocument, title: nil, viewState: $viewState) {
-            guard let consentDocument else {
-                return
-            }
-            onboardingData?.consentResponses = consentDocument.userResponses
-            let result = try consentDocument.export(using: pdfExportConfig)
+        OnboardingConsentView(consentDocument: document, title: nil, viewState: $viewState) {
+            onboardingData?.consentResponses = document.userResponses
+            let result = try document.export(using: pdfExportConfig)
             try await standard.uploadConsentDocument(result)
             do {
                 var accountDetailUpdates = AccountDetails()
                 accountDetailUpdates.lastSignedConsentDate = .now
-                accountDetailUpdates.lastSignedConsentVersion = consentDocument.metadata.version?.description
-                accountDetailUpdates.futureStudies = consentDocument.userResponses.toggleValue(for: .futureStudiesOptIn) == true
-                accountDetailUpdates.didOptInToTrial = consentDocument.userResponses.selectedOption(for: .trialOptIn) == .trialYes
+                accountDetailUpdates.lastSignedConsentVersion = document.metadata.version?.description
+                accountDetailUpdates.futureStudies = document.userResponses.toggleValue(for: .futureStudiesOptIn) == true
+                accountDetailUpdates.didOptInToTrial = document.userResponses.selectedOption(for: .trialOptIn) == .trialYes
                 let modifications = try AccountModifications(modifiedDetails: accountDetailUpdates)
                 try await account.accountService.updateAccountDetails(modifications)
             }
@@ -64,17 +59,10 @@ struct Consent: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 ConsentShareButton(
-                    consentDocument: consentDocument,
+                    consentDocument: document,
                     exportConfiguration: pdfExportConfig,
                     viewState: $viewState
                 )
-            }
-        }
-        .task {
-            do {
-                try await loadConsentDocument()
-            } catch {
-                logger.error("Failed to load/create ConsentDocument: \(error)")
             }
         }
     }
@@ -87,31 +75,9 @@ struct Consent: View {
     
     /// - parameter continueAction: An action which should be performed when the user submits the consent, to continue in the flow.
     ///     Defaults to `nil`, in which case the `Consent` view will advance its `ManagedNavigationStack`.
-    init(continueAction: (@MainActor () -> Void)? = nil) {
+    init(document: ConsentDocument, continueAction: (@MainActor () -> Void)? = nil) {
+        self.document = document
         self.continueAction = continueAction
-    }
-    
-    private func loadConsentDocument() async throws {
-        guard consentDocument == nil else {
-            return
-        }
-        // NOTE: we need to get the StudyBundle from the StudyBundleLoader, instead of the StudyManager,
-        // since the app won't necessarily be already enrolled at this point.
-        // (it is if this is a Consent renewal, but not during the initial onboarding...)
-        guard let studyBundle = try? studyLoader.studyBundle?.get(),
-              let consentFileRef = studyBundle.studyDefinition.metadata.consentFileRef,
-              let text = studyBundle.consentText(
-                for: consentFileRef,
-                in: studyManager.preferredLocale,
-                using: .requirePerfectMatch,
-                fallbackLocale: studyManager.defaultLanguageFallbackLocale
-              ) else {
-            return
-        }
-        consentDocument = try ConsentDocument(
-            markdown: text,
-            initialName: account.details?.name
-        )
     }
 }
 
@@ -128,7 +94,7 @@ extension Locale {
 
 #Preview {
     ManagedNavigationStack {
-        Consent()
+        Consent(document: .previewDoc)
     }
     .environment(StudyBundleLoader.shared)
     .environment(OnboardingDataCollection())

--- a/MyHeartCounts/Onboarding/ConsentRenewal/ConsentRenewalFlow.swift
+++ b/MyHeartCounts/Onboarding/ConsentRenewal/ConsentRenewalFlow.swift
@@ -11,6 +11,7 @@
 import Foundation
 import SFSafeSymbols
 import SpeziAccount
+import SpeziConsent
 import SpeziOnboarding
 import SpeziViews
 import SwiftUI
@@ -20,14 +21,17 @@ struct ConsentRenewalFlow: View {
     @Environment(\.dismiss)
     private var dismiss
     
+    let document: ConsentDocument
+    
     var body: some View {
         ManagedNavigationStack {
             ConsentRenewalExplainer()
-            Consent {
+            Consent(document: document) {
                 dismiss()
             }
         }
         .interactiveDismissDisabled()
+        .accessibilityIdentifier("MHC:ConsentRenewalFlow")
     }
 }
 
@@ -39,29 +43,20 @@ private struct ConsentRenewalExplainer: View {
     // swiftlint:enable attributes
     
     var body: some View {
-        OnboardingView {
-            VStack(alignment: .leading) {
-                OnboardingTitleView(title: "Consent Renewal")
-                Spacer()
-                HStack {
-                    Spacer()
-                    Image(systemSymbol: .textDocument)
-                        .font(.system(size: 150))
-                        .foregroundColor(.accentColor)
-                        .accessibilityHidden(true)
-                    Spacer()
-                }
-                Spacer()
-                let lastSignDate = account?.details?.lastSignedConsentDate
-                Text("""
-                    Our Study Consent document has been updated since you last signed it\(lastSignDate.map { " on \($0.formatted(.dateTime))" } ?? "").
-                    
-                    Please review the new Consent document and sign it again.
-                    """)
-                Spacer()
-            }
+        OnboardingPage(
+            symbol: .signature,
+            title: "Consent Renewal",
+            description: "CONSENT_RENEWAL_SUBTITLE"
+        ) {
+            let lastSignDate = account?.details?.lastSignedConsentDate
+            Text("""
+                Our Study Consent document has been updated since you last signed it\(lastSignDate.map { " on \($0.formatted(.dateTime))" } ?? "").
+
+                Please review the new Consent document and sign it again.
+                """)
+            Spacer()
         } footer: {
-            OnboardingActionsView("OK") {
+            OnboardingActionsView("Continue") {
                 path.nextStep()
             }
         }

--- a/MyHeartCounts/Onboarding/OnboardingConsentFlow.swift
+++ b/MyHeartCounts/Onboarding/OnboardingConsentFlow.swift
@@ -1,0 +1,186 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+// swiftlint:disable attributes file_types_order
+
+import SFSafeSymbols
+import Spezi
+import SpeziAccount
+import SpeziConsent
+import SpeziFoundation
+import SpeziOnboarding
+import SpeziStudy
+import SpeziViews
+import SwiftUI
+
+
+struct OnboardingConsentFlow: View {
+    // swiftlint:disable attributes
+    @Environment(ManagedNavigationStack.Path.self) private var path
+    @Environment(ConsentManager.self) private var consentManager
+    // swiftlint:enable attributes
+    
+    @State private var consentDoc: ConsentDocument?
+    @State private var viewState: ViewState = .idle
+    
+    var body: some View {
+        OnboardingPage(
+            symbol: .signature,
+            title: "Consent",
+            description: ""
+        ) {
+            switch viewState {
+            case .idle, .processing:
+                ProgressView("Loading Consent Document…" as String)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            case .error(let error):
+                ContentUnavailableView("Error", systemSymbol: .exclamationmarkOctagon, description: Text(error.localizedDescription))
+            }
+        }
+        .task {
+            do {
+                viewState = .processing
+                let doc = try await loadConsentDocument()
+                switch try consentManager.shouldSign(doc.metadata) {
+                case .no:
+                    // the user does not need to go through the whole flow,
+                    // so we go to the next regularly scheduled step
+                    path.nextStep()
+                case .yes:
+                    // the user needs to go through the whole consent flow
+                    path.append {
+                        Disclaimers(consentDoc: doc)
+                            .navigationBarBackButtonHidden()
+                    }
+                }
+            } catch {
+                viewState = .error(AnyLocalizedError(error: error))
+            }
+        }
+    }
+    
+    private func loadConsentDocument() async throws -> ConsentDocument {
+        if let consentDoc {
+            return consentDoc
+        }
+        let doc = try await consentManager.loadConsentDoc()
+        consentDoc = doc
+        return doc
+    }
+}
+
+
+private struct Disclaimers: View {
+    struct DisclaimerConfig {
+        let icon: SFSymbol
+        let title: LocalizedStringResource
+        let primaryText: LocalizedStringResource
+        let learnMoreText: LocalizedStringResource
+        let stepId: OnboardingStep
+    }
+    
+    @Environment(ManagedNavigationStack.Path.self)
+    private var path
+    
+    let step: DisclaimerConfig
+    let trailingSteps: [DisclaimerConfig]
+    let consentDoc: ConsentDocument
+    
+    @State private var isShowingLearnMoreText = false
+    
+    var body: some View {
+        OnboardingPage(symbol: step.icon, title: step.title, description: step.primaryText) {
+            EmptyView()
+        } footer: {
+            actionButtons
+        }
+        .sheet(isPresented: $isShowingLearnMoreText) {
+            OnboardingLearnMore(title: step.title, learnMoreText: step.learnMoreText)
+        }
+        .onboardingStep(step.stepId)
+        .injectingSpezi()
+    }
+    
+    private var actionButtons: some View {
+        OnboardingActionsView(
+            primaryTitle: "Continue",
+            primaryAction: {
+                next()
+            },
+            secondaryTitle: "Learn More",
+            secondaryAction: {
+                isShowingLearnMoreText = true
+            }
+        )
+    }
+    
+    init(step: DisclaimerConfig, trailing trailingSteps: some Collection<DisclaimerConfig>, consentDoc: ConsentDocument) {
+        self.step = step
+        self.trailingSteps = Array(trailingSteps)
+        self.consentDoc = consentDoc
+    }
+    
+    private func next() {
+        if let next = trailingSteps.first {
+            path.append {
+                Self(step: next, trailing: trailingSteps.dropFirst(), consentDoc: consentDoc)
+            }
+        } else {
+            // we've gone through all disclaimers, the next step is the Consent Comprehension
+            path.append {
+                ComprehensionScreening(consentDoc: consentDoc)
+            }
+        }
+    }
+}
+
+
+extension Disclaimers {
+    init(consentDoc: ConsentDocument) {
+        let steps: [DisclaimerConfig] = [
+            .init(
+                icon: .textPageBadgeMagnifyingglass,
+                title: "ONBOARDING_DISCLAIMER_1_TITLE",
+                primaryText: "ONBOARDING_DISCLAIMER_1_PRIMARY_TEXT",
+                learnMoreText: "ONBOARDING_DISCLAIMER_1_LEARN_MORE_TEXT",
+                stepId: .disclaimer1
+            ),
+            .init(
+                icon: .figureWalkMotion,
+                title: "ONBOARDING_DISCLAIMER_2_TITLE",
+                primaryText: "ONBOARDING_DISCLAIMER_2_PRIMARY_TEXT",
+                learnMoreText: "ONBOARDING_DISCLAIMER_2_LEARN_MORE_TEXT",
+                stepId: .disclaimer2
+            ),
+            .init(
+                icon: .lockSquareStack,
+                title: "ONBOARDING_DISCLAIMER_3_TITLE",
+                primaryText: "ONBOARDING_DISCLAIMER_3_PRIMARY_TEXT",
+                learnMoreText: "ONBOARDING_DISCLAIMER_3_LEARN_MORE_TEXT",
+                stepId: .disclaimer3
+            ),
+            .init(
+                icon: .documentOnClipboard,
+                title: "ONBOARDING_DISCLAIMER_4_TITLE",
+                primaryText: "ONBOARDING_DISCLAIMER_4_PRIMARY_TEXT",
+                learnMoreText: "ONBOARDING_DISCLAIMER_4_LEARN_MORE_TEXT",
+                stepId: .disclaimer4
+            )
+        ]
+        self.init(step: steps[0], trailing: steps.dropFirst(), consentDoc: consentDoc)
+    }
+}
+
+
+#if DEBUG
+extension ConsentDocument {
+    /// Intended for use in SwiftUI `#Preview`s within MHC
+    static let previewDoc = try! ConsentDocument(markdown: "Consent Text") // swiftlint:disable:this force_try
+}
+#endif

--- a/MyHeartCounts/Onboarding/OnboardingFlow.swift
+++ b/MyHeartCounts/Onboarding/OnboardingFlow.swift
@@ -60,55 +60,18 @@ private struct AppOnboardingFlow: View {
                     .navigationBarBackButtonHidden()
                     .onboardingStep(.login)
             }
-            OnboardingDisclaimerStep(
-                icon: .textPageBadgeMagnifyingglass,
-                title: "ONBOARDING_DISCLAIMER_1_TITLE",
-                primaryText: "ONBOARDING_DISCLAIMER_1_PRIMARY_TEXT",
-                learnMoreText: "ONBOARDING_DISCLAIMER_1_LEARN_MORE_TEXT"
-            )
-                .onboardingStep(.disclaimer1)
+            OnboardingConsentFlow()
                 .injectingSpezi()
-                // we hide the back button here, to prevent the user from returning to the "re-activate account" page
-                // (in case that's presented), since that yes/no decision should only be made once.
-                .navigationBarBackButtonHidden()
-            OnboardingDisclaimerStep(
-                icon: .figureWalkMotion,
-                title: "ONBOARDING_DISCLAIMER_2_TITLE",
-                primaryText: "ONBOARDING_DISCLAIMER_2_PRIMARY_TEXT",
-                learnMoreText: "ONBOARDING_DISCLAIMER_2_LEARN_MORE_TEXT"
-            )
-                .onboardingStep(.disclaimer2)
-                .injectingSpezi()
-            OnboardingDisclaimerStep(
-                icon: .lockSquareStack,
-                title: "ONBOARDING_DISCLAIMER_3_TITLE",
-                primaryText: "ONBOARDING_DISCLAIMER_3_PRIMARY_TEXT",
-                learnMoreText: "ONBOARDING_DISCLAIMER_3_LEARN_MORE_TEXT"
-            )
-                .onboardingStep(.disclaimer3)
-                .injectingSpezi()
-            OnboardingDisclaimerStep(
-                icon: .documentOnClipboard,
-                title: "ONBOARDING_DISCLAIMER_4_TITLE",
-                primaryText: "ONBOARDING_DISCLAIMER_4_PRIMARY_TEXT",
-                learnMoreText: "ONBOARDING_DISCLAIMER_4_LEARN_MORE_TEXT"
-            )
-                .onboardingStep(.disclaimer4)
-                .injectingSpezi()
-            ComprehensionScreening()
-                .onboardingStep(.comprehension)
-                .injectingSpezi()
-            #if !(targetEnvironment(simulator) && (arch(i386) || arch(x86_64)))
-            Consent()
-                .onboardingStep(.consent)
-                .injectingSpezi()
-                .navigationStepIdentifier("Consent")
-            #endif
+            // we hide the back button here, to prevent the user from returning to the "re-activate account" page
+            // (in case that's presented), since that yes/no decision should only be made once.
+            .navigationBarBackButtonHidden()
             if HKHealthStore.isHealthDataAvailable() {
                 // IDEA instead of having this in an if, we should probably have a full-screen "you can't participate" thing if the user doesn't have HealthKit?
                 HealthKitPermissions()
                     .onboardingStep(.healthAccess)
                     .injectingSpezi()
+                    // we don't want the user to be able to return to the Consent flow
+                    .navigationBarBackButtonHidden()
                 if ClinicalRecordPermissions.isAvailable && HealthRecordPermissions.includeInOnboarding {
                     HealthRecordPermissions()
                         .onboardingStep(.healthRecords)

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -1863,6 +1863,9 @@
         }
       }
     },
+    "CONSENT_RENEWAL_SUBTITLE" : {
+
+    },
     "Continue" : {
       "localizations" : {
         "en-GB" : {
@@ -1959,22 +1962,60 @@
         }
       }
     },
-    "Data collection enabled for %@ sensors" : {
-
-    },
     "Data collection enabled for %lld sensors" : {
-      "extractionState" : "stale",
       "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Data collection enabled for %lld sensor"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "Data collection enabled for %lld sensors"
+                }
+              }
+            }
+          }
+        },
         "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Data collection enabled for %lld sensors"
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Data collection enabled for %lld sensors"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Data collection enabled for %lld sensors"
+                }
+              }
+            }
           }
         },
         "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recopilación de datos habilitada para %lld sensores"
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Recopilación de datos habilitada para %lld sensores"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Recopilación de datos habilitada para %lld sensores"
+                }
+              }
+            }
           }
         }
       }

--- a/MyHeartCounts/Root View/RootView.swift
+++ b/MyHeartCounts/Root View/RootView.swift
@@ -10,6 +10,7 @@ import OSLog
 import SFSafeSymbols
 import Spezi
 import SpeziAccount
+import class SpeziConsent.ConsentDocument
 import SpeziFoundation
 import SpeziOnboarding
 import SpeziScheduler
@@ -30,7 +31,7 @@ struct RootView: View {
     @LocalPreference(.onboardingFlowComplete) private var didCompleteOnboarding
     // swiftlint:enable attributes
     
-    @State private var isShowingConsentRenewalSheet = false
+    @State private var consentDocForRenewal: ConsentDocument?
     
     var body: some View {
         ZStack {
@@ -55,15 +56,8 @@ struct RootView: View {
                 ContentUnavailableView("Error", systemSymbol: .exclamationmarkOctagon, description: Text(error.localizedDescription))
             }
         }
-        .onChange(of: consentManager?.needsToSignNewConsentVersion) { oldValue, newValue in
-            if let oldValue, let newValue, !oldValue && newValue {
-                isShowingConsentRenewalSheet = true
-            }
-        }
-        .sheet(isPresented: $isShowingConsentRenewalSheet) {
-            ConsentRenewalFlow()
-        }
         .trackingScenePhase()
+        .modifier(ConsentRenewalSheetModifier())
     }
 }
 
@@ -105,6 +99,25 @@ extension RootView {
                 ids.append(tab.accessibilityIdentifier)
             }
             return (content, ids)
+        }
+    }
+}
+
+
+extension RootView {
+    private struct ConsentRenewalSheetModifier: ViewModifier {
+        @Environment(ConsentManager.self)
+        private var consentManager: ConsentManager?
+        
+        func body(content: Content) -> some View {
+            if let consentManager {
+                @Bindable var consentManager = consentManager
+                content.sheet(item: $consentManager.pendingConsentDoc) { doc in
+                    ConsentRenewalFlow(document: doc)
+                }
+            } else {
+                content
+            }
         }
     }
 }

--- a/MyHeartCounts/SensorKit/SensorKitButton.swift
+++ b/MyHeartCounts/SensorKit/SensorKitButton.swift
@@ -61,7 +61,7 @@ struct SensorKitButton: View {
         case 0:
             "No data collection active"
         case let count:
-            "Data collection enabled for \(count, format: .number) sensors"
+            "Data collection enabled for \(count) sensors"
         }
         return makeLabel(title: "Manage SensorKit", subtitle: subtitle)
     }

--- a/MyHeartCounts/Utils/Debug Stuff/DebugForm.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/DebugForm.swift
@@ -30,6 +30,7 @@ struct DebugForm: View {
 
 
 private struct DebugFormImpl: View {
+    @Environment(MyHeartCountsStandard.self) private var standard
     @Environment(StudyManager.self) private var studyManager
     @Environment(DemoSetup.self) private var demoSetup
     @Environment(LocalNotifications.self) private var localNotifications
@@ -119,6 +120,9 @@ private struct DebugFormImpl: View {
                 }
                 CheckForUpdateButton {
                     Text(verbatim: "Check for App Update")
+                }
+                AsyncButton("Spezi Dependency Graph" as String) {
+                    print(await standard.spezi.moduleDependencyGraph.dotDescription)
                 }
             }
             Section {

--- a/MyHeartCounts/Utils/Debug Stuff/SpeziModuleDependencyGraph.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/SpeziModuleDependencyGraph.swift
@@ -1,0 +1,358 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+// periphery:ignore:all - Debugging API
+// swiftlint:disable all
+
+import Foundation
+@_spi(APISupport) // we need to access `Spezi.modules`
+import Spezi
+
+
+/// A snapshot of the dependency relationships between the `Module`s loaded into a `Spezi` instance.
+///
+/// Spezi doesn't publicly expose its modules' `@Dependency` declarations, so this type extracts them via reflection.
+/// It is therefore tied to the internal property-wrapper storage layout of the currently-pinned Spezi version
+/// (verified against SchmiedmayerLab/Spezi 0.1.4, rev `66208556`) and intended purely as a debugging aid;
+/// if Spezi's internals change, edges will be missing and reported via ``warnings``.
+///
+/// - Warning: Spezi itself crashes (stack overflow in `DependencyManager.buildTypeOrder()`) at the end of any
+///     `loadModules` pass whose injected module graph contains a cycle — i.e. before control ever returns to the app.
+///     ``cycles`` can therefore only ever surface a cycle that isn't fully injected yet
+///     (e.g. an un-injected optional back-edge that a later `Spezi/loadModule(_:ownership:)` call would complete).
+@MainActor
+struct SpeziModuleDependencyGraph {
+    /// How a module declared its dependency on another module.
+    enum EdgeKind: String {
+        /// A non-optional `@Dependency` declaration.
+        case required
+        /// An optional `@Dependency` declaration.
+        case optional
+        /// A `@Dependency(load:)` declaration.
+        case load
+    }
+
+    /// A loaded module.
+    struct Node: Hashable, Sendable {
+        /// Unique node identifier: the module's type name, disambiguated with `#N` if several instances of the same type are loaded.
+        let id: String
+        /// The name of the module's type.
+        let typeName: String
+    }
+
+    /// A `@Dependency` declaration of one module pointing at another.
+    struct Edge: Hashable, Sendable {
+        /// The ``Node/id`` of the module declaring the dependency.
+        let source: String
+        /// The ``Node/id`` of the target module or, if the dependency isn't injected, the declared type name.
+        let target: String
+        /// How the dependency was declared.
+        let kind: EdgeKind
+        /// Whether a module instance is currently injected into the declaration.
+        /// `false` e.g. for optional dependencies on modules that aren't loaded (yet).
+        let isInjected: Bool
+    }
+
+    /// The modules loaded into the `Spezi` instance.
+    private(set) var nodes: [Node] = []
+    /// All `@Dependency` edges declared by ``nodes``, including un-injected ones.
+    private(set) var edges: [Edge] = []
+    /// Diagnostic messages for `@Dependency` property wrappers whose contents couldn't be understood,
+    /// e.g. because the Spezi version in use has a different internal layout.
+    private(set) var warnings: [String] = []
+
+    /// Creates a snapshot of the dependency graph of all modules currently loaded into the `Spezi` instance.
+    init(_ spezi: Spezi) {
+        self.init(modules: spezi.modules)
+    }
+
+    /// Creates a snapshot of the dependency graph of the specified modules.
+    init(modules: [any Module]) {
+        var idsByInstance: [ObjectIdentifier: String] = [:]
+        let instanceCountsByType = modules.reduce(into: [:]) { counts, module in
+            counts["\(type(of: module))", default: 0] += 1
+        }
+        var seenCountsByType: [String: Int] = [:]
+        for module in modules {
+            let typeName = "\(type(of: module))"
+            let seenCount = seenCountsByType[typeName, default: 0] + 1
+            seenCountsByType[typeName] = seenCount
+            let id = instanceCountsByType[typeName, default: 1] > 1 ? "\(typeName) #\(seenCount)" : typeName
+            idsByInstance[ObjectIdentifier(module)] = id
+            nodes.append(Node(id: id, typeName: typeName))
+        }
+        for module in modules {
+            guard let sourceId = idsByInstance[ObjectIdentifier(module)] else {
+                continue
+            }
+            for declaration in Self.dependencyDeclarations(of: module, warnings: &warnings) {
+                let target: String
+                let isInjected: Bool
+                if let injected = declaration.injectedModule {
+                    target = idsByInstance[ObjectIdentifier(injected)] ?? "\(type(of: injected))"
+                    isInjected = true
+                } else {
+                    target = declaration.declaredTypeName
+                    isInjected = false
+                }
+                edges.append(Edge(source: sourceId, target: target, kind: declaration.kind, isInjected: isInjected))
+            }
+        }
+    }
+}
+
+
+// MARK: Cycle Detection
+
+extension SpeziModuleDependencyGraph {
+    /// All dependency cycles, as strongly connected components of more than one module, plus self-loops.
+    ///
+    /// Only edges with an injected module are considered; see the type-level warning about cycles Spezi crashes on itself.
+    var cycles: [[String]] {
+        stronglyConnectedComponents().filter { component in
+            component.count > 1 || edges.contains { $0.source == component[0] && $0.target == component[0] && $0.isInjected }
+        }
+    }
+
+    /// Computes the strongly connected components of the injected-edge graph, using an iterative Tarjan's algorithm.
+    private func stronglyConnectedComponents() -> [[String]] { // swiftlint:disable:this cyclomatic_complexity
+        let successors: [String: [String]] = edges.reduce(into: [:]) { successors, edge in
+            if edge.isInjected {
+                successors[edge.source, default: []].append(edge.target)
+            }
+        }
+        var index = 0
+        var indices: [String: Int] = [:]
+        var lowLinks: [String: Int] = [:]
+        var stack: [String] = []
+        var onStack: Set<String> = []
+        var components: [[String]] = []
+        for start in nodes.map(\.id) where indices[start] == nil {
+            var work: [(node: String, successorIdx: Int)] = [(start, 0)]
+            while let (node, successorIdx) = work.last {
+                if successorIdx == 0 {
+                    indices[node] = index
+                    lowLinks[node] = index
+                    index += 1
+                    stack.append(node)
+                    onStack.insert(node)
+                }
+                let nodeSuccessors = successors[node, default: []]
+                if successorIdx < nodeSuccessors.count {
+                    let successor = nodeSuccessors[successorIdx]
+                    work[work.count - 1].successorIdx += 1
+                    if indices[successor] == nil {
+                        work.append((successor, 0))
+                    } else if onStack.contains(successor), let successorIndex = indices[successor] {
+                        lowLinks[node] = min(lowLinks[node, default: index], successorIndex)
+                    }
+                    continue
+                }
+                if lowLinks[node] == indices[node] {
+                    var component: [String] = []
+                    while let member = stack.popLast() {
+                        onStack.remove(member)
+                        component.append(member)
+                        if member == node {
+                            break
+                        }
+                    }
+                    components.append(component)
+                }
+                work.removeLast()
+                if let (parent, _) = work.last {
+                    lowLinks[parent] = min(lowLinks[parent, default: index], lowLinks[node, default: index])
+                }
+            }
+        }
+        return components
+    }
+}
+
+
+// MARK: Exports
+
+extension SpeziModuleDependencyGraph {
+    /// A Graphviz DOT representation of the dependency graph.
+    ///
+    /// Required dependencies are drawn as solid edges, optional ones dashed, `load` ones with a label;
+    /// un-injected dependencies are gray, and any edges participating in a cycle are highlighted in red.
+    /// Render e.g. via `dot -Tpdf graph.dot -o graph.pdf`, or by pasting into an online Graphviz viewer.
+    var dotDescription: String {
+        var cycleComponentById: [String: Int] = [:]
+        for (componentIdx, component) in cycles.enumerated() {
+            for member in component {
+                cycleComponentById[member] = componentIdx
+            }
+        }
+        var lines = [
+            "digraph SpeziModuleDependencies {",
+            "    rankdir=LR",
+            "    node [shape=box, fontname=\"Helvetica\"]"
+        ]
+        for node in nodes.sorted(using: KeyPathComparator(\.id)) {
+            lines.append("    \(Self.quoted(node.id))")
+        }
+        for ghost in Set(edges.filter { !$0.isInjected }.map(\.target)).subtracting(nodes.map(\.id)).sorted() {
+            lines.append("    \(Self.quoted(ghost)) [color=gray, fontcolor=gray, style=dashed]")
+        }
+        for edge in edges.sorted(using: [KeyPathComparator(\.source), KeyPathComparator(\.target)]) {
+            var attributes: [String] = []
+            if edge.kind == .optional {
+                attributes.append("style=dashed")
+            }
+            if edge.kind == .load {
+                attributes.append("label=\"load\"")
+            }
+            if !edge.isInjected {
+                attributes.append("color=gray")
+            } else if let component = cycleComponentById[edge.source], cycleComponentById[edge.target] == component {
+                attributes.append("color=red")
+                attributes.append("penwidth=2")
+            }
+            let suffix = attributes.isEmpty ? "" : " [\(attributes.joined(separator: ", "))]"
+            lines.append("    \(Self.quoted(edge.source)) -> \(Self.quoted(edge.target))\(suffix)")
+        }
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+
+    /// An indented, human-readable tree representation of the dependency graph, starting at the modules nothing depends on.
+    ///
+    /// Every module's dependency subtree is expanded only once; further occurrences are marked with `↩`.
+    var treeDescription: String {
+        struct WorkItem {
+            let id: String
+            let depth: Int
+            /// The kind of the edge we arrived at this module through.
+            let kind: EdgeKind?
+        }
+        let hasIncomingEdge = Set(edges.filter(\.isInjected).map(\.target))
+        let roots = nodes.filter { !hasIncomingEdge.contains($0.id) }.map(\.id)
+        var lines: [String] = []
+        var expanded: Set<String> = []
+        var work: [WorkItem] = (roots.isEmpty ? nodes.map(\.id) : roots)
+            .sorted()
+            .reversed()
+            .map { WorkItem(id: $0, depth: 0, kind: nil) }
+        while let item = work.popLast() {
+            let indent = String(repeating: "    ", count: item.depth)
+            let kindSuffix = item.kind.map { $0 == .required ? "" : " (\($0.rawValue))" } ?? ""
+            let isFirstExpansion = expanded.insert(item.id).inserted
+            let outgoing = edges.filter { $0.source == item.id }
+            lines.append("\(indent)\(item.id)\(kindSuffix)\(isFirstExpansion || outgoing.isEmpty ? "" : " ↩")")
+            guard isFirstExpansion else {
+                continue
+            }
+            for edge in outgoing.sorted(using: KeyPathComparator(\.target)).reversed() {
+                if edge.isInjected {
+                    work.append(WorkItem(id: edge.target, depth: item.depth + 1, kind: edge.kind))
+                } else {
+                    lines.append("\(indent)    \(edge.target) (\(edge.kind.rawValue), not injected)")
+                }
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func quoted(_ identifier: String) -> String {
+        "\"\(identifier.replacingOccurrences(of: "\"", with: "\\\""))\""
+    }
+}
+
+
+// MARK: Reflection-based Edge Extraction
+
+extension SpeziModuleDependencyGraph {
+    private struct ExtractedDeclaration {
+        let declaredTypeName: String
+        let kind: EdgeKind
+        let injectedModule: (any Module)?
+    }
+
+    /// Extracts all `@Dependency` declarations of a module, by mirroring into Spezi's
+    /// `_DependencyPropertyWrapper` → `DependencyCollection` → `DependencyContext<M>` storage.
+    private static func dependencyDeclarations(of module: any Module, warnings: inout [String]) -> [ExtractedDeclaration] {
+        var declarations: [ExtractedDeclaration] = []
+        for child in Mirror(reflecting: module).children {
+            guard "\(type(of: child.value))".hasPrefix("_DependencyPropertyWrapper<") else {
+                continue
+            }
+            let property = "\(type(of: module)).\(child.label ?? "?")"
+            guard let collection = Mirror(reflecting: child.value).descendant("dependencies") else {
+                warnings.append("\(property): no 'dependencies' collection; did Spezi's internal layout change?")
+                continue
+            }
+            guard let entries = Mirror(reflecting: collection).descendant("entries") else {
+                warnings.append("\(property): no 'entries' in DependencyCollection; did Spezi's internal layout change?")
+                continue
+            }
+            for entry in Mirror(reflecting: entries).children.map(\.value) {
+                if let declaration = extractDeclaration(from: entry) {
+                    declarations.append(declaration)
+                } else {
+                    warnings.append("\(property): unable to decode entry of type \(type(of: entry))")
+                }
+            }
+        }
+        return declarations
+    }
+
+    /// Decodes a single Spezi `DependencyContext<M>` instance.
+    private static func extractDeclaration(from entry: Any) -> ExtractedDeclaration? {
+        // "DependencyContext<SomeModule>" → "SomeModule"
+        let entryTypeName = "\(type(of: entry))"
+        guard entryTypeName.hasPrefix("DependencyContext<"), entryTypeName.hasSuffix(">"),
+              let kindValue = Mirror(reflecting: entry).descendant("type") else {
+            return nil
+        }
+        let declaredTypeName = String(entryTypeName.dropFirst("DependencyContext<".count).dropLast())
+        let kind = EdgeKind(rawValue: "\(kindValue)") ?? .required
+        var injected: (any Module)?
+        if let injectedValue = Mirror(reflecting: entry).descendant("injectedDependency"),
+           let reference = flattenedOptional(injectedValue) {
+            injected = moduleFromDynamicReference(reference)
+        }
+        return ExtractedDeclaration(declaredTypeName: declaredTypeName, kind: kind, injectedModule: injected)
+    }
+
+    /// Resolves Spezi's `DynamicReference<M>` enum (`.element(M)` / `.weakElement(WeaklyStoredElement)`) to the referenced module.
+    private static func moduleFromDynamicReference(_ reference: Any) -> (any Module)? {
+        guard let payload = Mirror(reflecting: reference).children.first?.value else {
+            return nil
+        }
+        if let module = payload as? any Module {
+            return module
+        }
+        // .weakElement stores a WeaklyStoredElement struct wrapping a weak optional reference
+        guard let wrappedReference = Mirror(reflecting: payload).children.first?.value,
+              let element = flattenedOptional(wrappedReference) else {
+            return nil
+        }
+        return element as? any Module
+    }
+
+    private static func flattenedOptional(_ value: Any) -> Any? {
+        let mirror = Mirror(reflecting: value)
+        guard mirror.displayStyle == .optional else {
+            return value
+        }
+        guard let wrapped = mirror.children.first?.value else {
+            return nil
+        }
+        return flattenedOptional(wrapped)
+    }
+}
+
+
+extension Spezi {
+    /// Computes a snapshot of the dependency graph between all currently loaded modules.
+    @MainActor var moduleDependencyGraph: SpeziModuleDependencyGraph {
+        SpeziModuleDependencyGraph(self)
+    }
+}

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/LaunchOptions.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/LaunchOptions.swift
@@ -56,7 +56,14 @@ public struct LaunchOptionDecodingContext: Sendable {
 
 public protocol LaunchOptionsContainerProtocol: Sendable {
     func _value<V>(for option: LaunchOption<V>) -> V? // swiftlint:disable:this identifier_name
+    
+    /// Performs a fresh decode of the option, ignoring any potential cached, previously decoded values.
+    ///
+    /// - returns: the decoded value, or `nil` if the container did not contain an entry for the option
+    /// - throws: if the container did contain an entry for the option, but it failed to decode.
+    func _decode<V>(_ option: LaunchOption<V>) throws -> V? // swiftlint:disable:this identifier_name
 }
+
 
 extension LaunchOptionsContainerProtocol {
     /// Returns the specified `option`'s decoded launch option argument, falling back to its default value if no argument was specified.
@@ -154,6 +161,22 @@ private struct CombinedLaunchOptionsContainer: LaunchOptionsContainerProtocol {
         }
         return nil
     }
+    
+    func _decode<V>(_ option: LaunchOption<V>) throws -> V? { // swiftlint:disable:this identifier_name
+        var mostRecentError: (any Error)?
+        for container in containers {
+            do {
+                return try container._decode(option)
+            } catch {
+                mostRecentError = error
+            }
+        }
+        if let mostRecentError {
+            throw mostRecentError
+        } else {
+            return nil
+        }
+    }
 }
 
 
@@ -250,17 +273,25 @@ private struct CommandLineLaunchOptionsContainer: LaunchOptionsContainerProtocol
             if let value {
                 return value
             }
-            guard let optionRawArgs = parsedArguments.options[option.key] else {
-                return nil
-            }
             do {
-                value = try V(decodingLaunchOption: LaunchOptionDecodingContext(rawArgs: optionRawArgs))
-                return value
+                if let decoded = try _decode(option) {
+                    value = decoded
+                    return decoded
+                } else {
+                    return nil
+                }
             } catch {
                 print("Unable to parse value for option '\(option.key)': \(error)")
                 return nil
             }
         }
+    }
+    
+    func _decode<V>(_ option: LaunchOption<V>) throws -> V? { // swiftlint:disable:this identifier_name
+        guard let optionRawArgs = parsedArguments.options[option.key] else {
+            return nil
+        }
+        return try V(decodingLaunchOption: LaunchOptionDecodingContext(rawArgs: optionRawArgs))
     }
 }
 

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/Other.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/Other.swift
@@ -8,15 +8,47 @@
 
 #if !os(Linux)
 
+public import struct SpeziFoundation.Version
+
+
 extension LaunchOptions {
     /// Whether we should force-enable the debug mode, even if the account key is set to `false`.
     ///
     /// - Note: Specifying `false` for this option when the account key is `true` will not force-disable the debug mode.
     public static let forceEnableDebugMode = LaunchOption<Bool>("--forceEnableDebugMode", default: false)
     
-    
     /// Whether the app should enable its HealthKit Clinical Records integration
     public static let enableHealthRecords = LaunchOption<Bool>("--enableHealthRecords", default: true)
+    
+    /// Whether the "please sign the new consent version" sheet should be presented to the user if they've never signed the consent before.
+    ///
+    /// Defaults to true; the option exists to allow the UI tests (which typically use temporary users that don't have a signed consent) to suppress the sheet.
+    public static let triggerConsentRenewalIfNeverSigned = LaunchOption<Bool>("--triggerConsentRenewalIfNeverSigned", default: true)
+}
+
+
+extension LaunchOptions {
+    /// Force-overrides the last-signed consent version, if the app is being launched with ``setupTestEnvironment`` present.
+    ///
+    /// Intended solely for UI testing purposes.
+    public static let overrideLastSignedConsentVersion = LaunchOption<Version?>("--overrideLastSignedConsentVersion", default: nil)
+}
+
+
+extension Version: LaunchOptionDecodable, LaunchOptionEncodable {
+    public init(decodingLaunchOption context: LaunchOptionDecodingContext) throws {
+        try context.assertNumRawArgs(.equal(1))
+        let raw = context.rawArgs[0]
+        if let version = Version(raw) {
+            self = version
+        } else {
+            throw LaunchOptionDecodingError.unableToDecode(Self.self, rawValue: raw)
+        }
+    }
+    
+    public func launchOptionArgs(for launchOption: LaunchOption<Version>) -> [String] {
+        [launchOption.key, self.description]
+    }
 }
 
 #endif

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/SetupTestEnvironmentConfig.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/SetupTestEnvironmentConfig.swift
@@ -78,16 +78,18 @@ extension SetupTestEnvironmentConfig: LaunchOptionDecodable, LaunchOptionEncodab
                     // the option is present, but no credentials are supplied.
                     return .enable(.default)
                 }
-                if arg[colonIdx...].dropFirst() == "random" {
+                let emailAndPassword = arg[colonIdx...].dropFirst()
+                if emailAndPassword == "random" {
                     return .enable(.random())
                 }
-                let components = arg[colonIdx...].dropFirst().split(separator: ";")
-                guard components.count == 2 else {
+                guard let sepIdx = emailAndPassword.firstIndex(of: ";") else {
                     throw LaunchOptionDecodingError.unableToDecode(Self.self, rawValue: arg)
                 }
+                let email = emailAndPassword[..<sepIdx]
+                let password = emailAndPassword[sepIdx...].dropFirst()
                 return .enable(Credentials(
-                    username: String(components[0]),
-                    password: String(components[1])
+                    username: String(email),
+                    password: String(password)
                 ))
             }()
         )
@@ -120,8 +122,10 @@ extension SetupTestEnvironmentConfig.Credentials {
     /// Creates new, random `Credentials`
     public static func random() -> Self {
         Self(
-            username: "\(String.random(from: .alphanumerics, length: 5))@stanford.edu",
-            password: .random(from: .printableASCII, length: 12)
+            username: "\(String.random(from: .alphanumerics, length: 7))@stanford.edu",
+            password: .random(from: .printableASCII.excluding("' "), length: 12)
+            // ^ we need to disallow `'`s to work around FB23653577
+            //   we also disallow ` ` just to be safe
         )
     }
 }

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/String+Random.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/String+Random.swift
@@ -23,6 +23,10 @@ extension String {
         public static func + (lhs: Self, rhs: Self) -> Self {
             Self(lhs.pool.union(rhs.pool))
         }
+        
+        public func excluding(_ chars: some Sequence<Character>) -> Alphabet {
+            Alphabet(pool.subtracting(chars))
+        }
     }
 }
 

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Version+Utils.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Version+Utils.swift
@@ -1,0 +1,35 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+// periphery:ignore:all - API
+
+public import struct SpeziFoundation.Version
+
+
+extension Version {
+    /// The version succeeding this version's major component, i.e. `(major+1).0.0`.
+    ///
+    /// - Note: Any pre-release identifiers or build metadata are discarded.
+    @inlinable public var nextMajor: Version {
+        Version(major + 1, 0, 0)
+    }
+    
+    /// The version succeeding this version's minor component, i.e. `major.(minor+1).0`.
+    ///
+    /// - Note: Any pre-release identifiers or build metadata are discarded.
+    @inlinable public var nextMinor: Version {
+        Version(major, minor + 1, 0)
+    }
+    
+    /// The version succeeding this version's patch component, i.e. `major.minor.(patch+1)`.
+    ///
+    /// - Note: Any pre-release identifiers or build metadata are discarded.
+    @inlinable public var nextPatch: Version {
+        Version(major, minor, patch + 1)
+    }
+}

--- a/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/MHCLaunchOptionsTests.swift
+++ b/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/MHCLaunchOptionsTests.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if !os(Linux)
+
+import Foundation
+@testable import MyHeartCountsShared
+import Testing
+
+
+@Suite
+struct MHCLaunchOptionsTests {
+    @Test
+    func setupEnvConfig() throws {
+        let input = SetupTestEnvironmentConfig(
+            resetExistingData: true,
+            loginAndEnroll: .enable(.init(username: "LoMhrYN@stanford.edu", password: ">G;IFozm$]+M"))
+        )
+        let argvInput = input.launchOptionArgs(for: .setupTestEnvironment)
+        #expect(argvInput == [
+            "--setupTestEnvironment", "reset", "login-and-enroll:LoMhrYN@stanford.edu;>G;IFozm$]+M"
+        ])
+        let container = LaunchOptions.commandLineOptionsContainer(for: [""] + argvInput)
+        let parsed = try container._decode(.setupTestEnvironment)
+        #expect(parsed == input)
+    }
+}
+
+#endif

--- a/MyHeartCountsUITests/AOnboardingTests.swift
+++ b/MyHeartCountsUITests/AOnboardingTests.swift
@@ -249,7 +249,7 @@ struct OnboardingNavigator { // swiftlint:disable:this type_body_length
     }
     
     
-    private func navigateConsent(expectedName: PersonNameComponents?, signUpForExtraTrial: Bool) { // swiftlint:disable:this function_body_length
+    func navigateConsent(expectedName: PersonNameComponents?, signUpForExtraTrial: Bool) { // swiftlint:disable:this function_body_length
         sleep(for: .seconds(2))
         XCTAssert(app.scrollViews.staticTexts["STANFORD UNIVERSITY"].waitForExistence(timeout: 2))
         XCTAssert(app.scrollViews.staticTexts["CONSENT TO BE PART OF A RESEARCH STUDY"].waitForExistence(timeout: 2))

--- a/MyHeartCountsUITests/AOnboardingTests.swift
+++ b/MyHeartCountsUITests/AOnboardingTests.swift
@@ -31,14 +31,15 @@ final class AOnboardingTests: MHCTestCase, Sendable {
             locale: .enUS,
             testEnvironmentConfig: .init(resetExistingData: true, loginAndEnroll: .skip),
             skipHealthPermissionsHandling: true,
-            skipGoingToHomeTab: true,
+            skipGoingToHomeTab: true
         )
         let navigator = OnboardingNavigator(testCase: self)
         try navigator.navigateFullOnboardingFlow(
             region: .unitedStates,
             name: .init(givenName: "Leland", familyName: "Stanford"),
             credentials: .default,
-            signUpForExtraTrial: true
+            signUpForExtraTrial: true,
+            consentPresenceCheck: .dontCare
         )
     }
     
@@ -96,6 +97,12 @@ final class AOnboardingTests: MHCTestCase, Sendable {
 
 @MainActor
 struct OnboardingNavigator { // swiftlint:disable:this type_body_length
+    enum ConsentPresenceCheck {
+        case assertPresent
+        case assertSkipped
+        case dontCare
+    }
+    
     let testCase: MHCTestCase
     
     private var app: XCUIApplication {
@@ -103,18 +110,49 @@ struct OnboardingNavigator { // swiftlint:disable:this type_body_length
     }
     
     
-    func navigateFullOnboardingFlow(
+    func navigateOnboardingFlowUntilHealthKit(
         region: Locale.Region,
         name: PersonNameComponents,
         credentials: SetupTestEnvironmentConfig.Credentials,
-        signUpForExtraTrial: Bool
+        signUpForExtraTrial: Bool,
+        consentPresenceCheck: ConsentPresenceCheck
     ) throws {
         navigateWelcome()
         try navigateEligibility(region: region)
         try navigateSignup(name: name, credentials: credentials)
-        navigateOnboardingDisclaimers()
-        navigateConsentComprehension()
-        navigateConsent(expectedName: name, signUpForExtraTrial: signUpForExtraTrial)
+        let consentFlowIndicator = app.staticTexts["Study Overview & Participation"]
+        let noConsentFlowIndicator = app.staticTexts["HealthKit Access"]
+        switch consentPresenceCheck {
+        case .assertPresent:
+            XCTAssert(consentFlowIndicator.waitForExistence(timeout: 5))
+        case .assertSkipped:
+            XCTAssertFalse(consentFlowIndicator.waitForExistence(timeout: 5))
+            XCTAssert(noConsentFlowIndicator.waitForExistence(timeout: 5))
+        case .dontCare:
+            break
+        }
+        if consentFlowIndicator.waitForExistence(timeout: 5) {
+            navigateOnboardingDisclaimers()
+            navigateConsentComprehension()
+            navigateConsent(expectedName: name, signUpForExtraTrial: signUpForExtraTrial)
+        }
+        XCTAssert(app.staticTexts["HealthKit Access"].waitForExistence(timeout: 10))
+    }
+    
+    func navigateFullOnboardingFlow(
+        region: Locale.Region,
+        name: PersonNameComponents,
+        credentials: SetupTestEnvironmentConfig.Credentials,
+        signUpForExtraTrial: Bool,
+        consentPresenceCheck: ConsentPresenceCheck
+    ) throws {
+        try navigateOnboardingFlowUntilHealthKit(
+            region: region,
+            name: name,
+            credentials: credentials,
+            signUpForExtraTrial: signUpForExtraTrial,
+            consentPresenceCheck: consentPresenceCheck
+        )
         navigateHealthKitAccess()
         if app.staticTexts["Health Records"].waitForExistence(timeout: 2) { // only included if Health Records are actually available
             navigateHealthRecords()

--- a/MyHeartCountsUITests/ConsentRenewalTests.swift
+++ b/MyHeartCountsUITests/ConsentRenewalTests.swift
@@ -1,0 +1,151 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Algorithms
+import MyHeartCountsShared
+import SpeziFoundation
+import SpeziStudyDefinition
+import XCTest
+import XCTestExtensions
+
+
+final class ConsentRenewalTests: MHCTestCase, Sendable {
+    private func onDiskConsentVersion(for locale: Locale) throws -> Version {
+        let studyBundle = try StudyBundle(bundleUrl: try XCTUnwrap(studyBundleUrl))
+        let consentFileRef = try XCTUnwrap(studyBundle.studyDefinition.metadata.consentFileRef)
+        let url = try XCTUnwrap(studyBundle.resolve(consentFileRef, in: locale))
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let match = try XCTUnwrap(text.firstMatch(of: /^version: (?<value>.*)$/.anchorsMatchLineEndings()))
+        return try XCTUnwrap(Version(String(match.output.value)))
+    }
+    
+    
+    func testConsentRenewalNewMajor() throws {
+        try _implTestConsentRenewal(nextVersion: \.nextMajor, expectRenewalFlow: true)
+    }
+    
+    func testConsentRenewalNewMinor() throws {
+        try _implTestConsentRenewal(nextVersion: \.nextMinor, expectRenewalFlow: true)
+    }
+    
+    func testConsentRenewalNewPatch() throws {
+        try _implTestConsentRenewal(nextVersion: \.nextPatch, expectRenewalFlow: false)
+    }
+    
+    
+    /// Test the consent renewal flow.
+    ///
+    /// This test verifies that if the last-signed consent version is lower than the current one, the app prompts the user to renew their consent
+    /// (unless the patch was changed and major and minor remain equal).
+    /// It also checks that if the last-signed version is equal to the current one in major and minor, and only the patch is smaller (ie, a new consent revision
+    /// has been published since the user signed the consent, but it only differs in the patch component), no renewal flow is presented.
+    private func _implTestConsentRenewal( // swiftlint:disable:this function_body_length
+        nextVersion nextVersionKeyPath: KeyPath<Version, Version>,
+        expectRenewalFlow: Bool
+    ) throws {
+        let locale: Locale = .enUS
+        
+        func overwriteOnDiskConsentVersion(to newVersion: Version) throws {
+            let studyBundle = try StudyBundle(bundleUrl: try XCTUnwrap(studyBundleUrl))
+            let consentFileRef = try XCTUnwrap(studyBundle.studyDefinition.metadata.consentFileRef)
+            let url = try XCTUnwrap(studyBundle.resolve(consentFileRef, in: locale))
+            var text = try String(contentsOf: url, encoding: .utf8)
+            text.replace(/^version: (.*)$/.anchorsMatchLineEndings(), maxReplacements: 1) { _ in
+                "version: \(newVersion.description)"
+            }
+            try Data(text.utf8).write(to: url)
+        }
+        
+        let config = SetupTestEnvironmentConfig(
+            // note: having the reset here happen is important for the test below to work properly,
+            // since otherwise we'd also need to increment the study bundle revision each time we launch
+            // the app with a new consent version. (bc otherwise it wouldn't update the study bundle w/in
+            // SpeziStudy, but if we first reset the app it won't have a prev enrollment and will simply
+            // ingest the new one. which is exactly what we want, since the lastSignedConsentVersion
+            // is stored on the server anyway.)
+            resetExistingData: true,
+            loginAndEnroll: .enable(.random())
+        )
+        try launchAppAndEnrollIntoStudy(
+            locale: locale,
+            testEnvironmentConfig: config
+        )
+        // no consent renewal flow
+        XCTAssert(app.staticTexts.matching("label CONTAINS[c] %@", "Consent").element.waitForNonExistence(timeout: 5))
+        
+        /// Fetches the last-signed consent version, via the account sheet
+        ///
+        /// - invariant: requires that the app be on either of the root-level tabs, and no sheets are open.
+        func determineLastSignedConsentVersion() -> Version? {
+            openAccountSheet()
+            app.swipeUp()
+            app.swipeUp()
+            XCTAssert(app.otherElements["MHC:AboutRow"].waitForExistence(timeout: 2))
+            app.otherElements["MHC:AboutRow"].tap(withNumberOfTaps: 5, numberOfTouches: 1)
+            
+            let sheet = app.otherElements["MHC:AboutRow:ExtendedInfoSheet"]
+            XCTAssert(sheet.waitForExistence(timeout: 2))
+            app.expandSheet(sheet)
+            
+            let label = sheet.staticTexts.matching("label LIKE %@", "lastSignedConsentVersion, *.*.*").element.label
+            let versionPart = String(label.suffix { !$0.isWhitespace })
+            let version = Version(versionPart)
+            // dismiss the extended info sheet
+            sheet.navigationBars.buttons["Close"].tap()
+            closeAccountSheet()
+            return version
+        }
+        
+        // verify that the test env setup will have implicitly had the user sign the current consent.
+        XCTAssertEqual(try XCTUnwrap(determineLastSignedConsentVersion()), try onDiskConsentVersion(for: locale))
+        app.terminate()
+        
+        let initialOnDiskConsentVersion = try onDiskConsentVersion(for: locale)
+        let nextConsentVersion = initialOnDiskConsentVersion[keyPath: nextVersionKeyPath]
+        
+        if expectRenewalFlow {
+            // Step 2: check that the new version triggers renewal
+            try overwriteOnDiskConsentVersion(to: nextConsentVersion)
+            try launchAppAndEnrollIntoStudy(
+                locale: locale,
+                testEnvironmentConfig: config,
+                skipHealthPermissionsHandling: true,
+                skipGoingToHomeTab: true
+            )
+            // the study bundle now contains a new consent version than what was signed before, which we expect to trigger the renewal flow.
+            XCTAssert(app.otherElements["MHC:ConsentRenewalFlow"].waitForExistence(timeout: 7))
+            XCTAssert(app.staticTexts["Consent Renewal"].exists)
+            app.buttons["Continue"].tap()
+            
+            let onboardingNavigator = OnboardingNavigator(testCase: self)
+            onboardingNavigator.navigateConsent(
+                expectedName: PersonNameComponents(givenName: "Leland", familyName: "Stanford"),
+                signUpForExtraTrial: false
+            )
+            XCTAssert(app.otherElements["MHC:ConsentRenewalFlow"].waitForNonExistence(timeout: 7))
+            // verify that the user is now recorded as having signed the new version
+            XCTAssertEqual(try XCTUnwrap(determineLastSignedConsentVersion()), nextConsentVersion)
+            app.terminate()
+        }
+        
+        // launch again and verify no second prompt will take place.
+        try launchAppAndEnrollIntoStudy(
+            locale: locale,
+            testEnvironmentConfig: config,
+            skipHealthPermissionsHandling: true,
+            skipGoingToHomeTab: true
+        )
+        XCTAssert(app.otherElements["MHC:ConsentRenewalFlow"].waitForNonExistence(timeout: 10))
+        if expectRenewalFlow {
+            // verify that the user is still recorded as having signed the new version
+            XCTAssertEqual(try XCTUnwrap(determineLastSignedConsentVersion()), nextConsentVersion)
+        } else {
+            XCTAssertEqual(try XCTUnwrap(determineLastSignedConsentVersion()), initialOnDiskConsentVersion)
+        }
+    }
+}

--- a/MyHeartCountsUITests/ConsentRenewalTests.swift
+++ b/MyHeartCountsUITests/ConsentRenewalTests.swift
@@ -7,14 +7,16 @@
 //
 
 import Algorithms
+import HealthKit
 import MyHeartCountsShared
 import SpeziFoundation
 import SpeziStudyDefinition
 import XCTest
 import XCTestExtensions
+import XCTHealthKit
 
 
-final class ConsentRenewalTests: MHCTestCase, Sendable {
+final class ConsentTests: MHCTestCase, Sendable {
     private func onDiskConsentVersion(for locale: Locale) throws -> Version {
         let studyBundle = try StudyBundle(bundleUrl: try XCTUnwrap(studyBundleUrl))
         let consentFileRef = try XCTUnwrap(studyBundle.studyDefinition.metadata.consentFileRef)
@@ -22,6 +24,62 @@ final class ConsentRenewalTests: MHCTestCase, Sendable {
         let text = try String(contentsOf: url, encoding: .utf8)
         let match = try XCTUnwrap(text.firstMatch(of: /^version: (?<value>.*)$/.anchorsMatchLineEndings()))
         return try XCTUnwrap(Version(String(match.output.value)))
+    }
+    
+    func overwriteOnDiskConsentVersion(for locale: Locale, to newVersion: Version) throws {
+        let studyBundle = try StudyBundle(bundleUrl: try XCTUnwrap(studyBundleUrl))
+        let consentFileRef = try XCTUnwrap(studyBundle.studyDefinition.metadata.consentFileRef)
+        let url = try XCTUnwrap(studyBundle.resolve(consentFileRef, in: locale))
+        var text = try String(contentsOf: url, encoding: .utf8)
+        text.replace(/^version: (.*)$/.anchorsMatchLineEndings(), maxReplacements: 1) { _ in
+            "version: \(newVersion.description)"
+        }
+        try Data(text.utf8).write(to: url)
+    }
+    
+    
+    func testSkipDuringOnboardingIfAlreadySupplied() throws {
+        let locale: Locale = .enUS
+        let credentials: SetupTestEnvironmentConfig.Credentials = .random()
+        
+        try launchHealthAppAndEnterCharacteristics(.init(
+            bloodType: .aPositive,
+            dateOfBirth: .init(year: 1998, month: 6, day: 2),
+            biologicalSex: .male,
+            skinType: .II,
+            wheelchairUse: .no
+        ))
+        try launchAppAndEnrollIntoStudy(
+            locale: locale,
+            testEnvironmentConfig: .init(resetExistingData: true, loginAndEnroll: .skip),
+            skipHealthPermissionsHandling: true,
+            skipGoingToHomeTab: true
+        )
+        let navigator = OnboardingNavigator(testCase: self)
+        try navigator.navigateFullOnboardingFlow(
+            region: try XCTUnwrap(locale.region),
+            name: .init(givenName: "Leland", familyName: "Stanford"),
+            credentials: credentials,
+            signUpForExtraTrial: false,
+            consentPresenceCheck: .assertPresent
+        )
+        XCTAssert(app.staticTexts["Welcome to My Heart Counts"].exists)
+        app.terminate()
+        
+        try launchAppAndEnrollIntoStudy(
+            locale: locale,
+            testEnvironmentConfig: .init(resetExistingData: true, loginAndEnroll: .skip),
+            skipHealthPermissionsHandling: true,
+            skipGoingToHomeTab: true
+        )
+        
+        try navigator.navigateOnboardingFlowUntilHealthKit(
+            region: try XCTUnwrap(locale.region),
+            name: .init(givenName: "Leland", familyName: "Stanford"),
+            credentials: credentials,
+            signUpForExtraTrial: false,
+            consentPresenceCheck: .assertSkipped
+        )
     }
     
     
@@ -49,17 +107,6 @@ final class ConsentRenewalTests: MHCTestCase, Sendable {
         expectRenewalFlow: Bool
     ) throws {
         let locale: Locale = .enUS
-        
-        func overwriteOnDiskConsentVersion(to newVersion: Version) throws {
-            let studyBundle = try StudyBundle(bundleUrl: try XCTUnwrap(studyBundleUrl))
-            let consentFileRef = try XCTUnwrap(studyBundle.studyDefinition.metadata.consentFileRef)
-            let url = try XCTUnwrap(studyBundle.resolve(consentFileRef, in: locale))
-            var text = try String(contentsOf: url, encoding: .utf8)
-            text.replace(/^version: (.*)$/.anchorsMatchLineEndings(), maxReplacements: 1) { _ in
-                "version: \(newVersion.description)"
-            }
-            try Data(text.utf8).write(to: url)
-        }
         
         let config = SetupTestEnvironmentConfig(
             // note: having the reset here happen is important for the test below to work properly,
@@ -110,7 +157,7 @@ final class ConsentRenewalTests: MHCTestCase, Sendable {
         
         if expectRenewalFlow {
             // Step 2: check that the new version triggers renewal
-            try overwriteOnDiskConsentVersion(to: nextConsentVersion)
+            try overwriteOnDiskConsentVersion(for: locale, to: nextConsentVersion)
             try launchAppAndEnrollIntoStudy(
                 locale: locale,
                 testEnvironmentConfig: config,

--- a/MyHeartCountsUITests/MHCTestCase.swift
+++ b/MyHeartCountsUITests/MHCTestCase.swift
@@ -44,10 +44,8 @@ class MHCTestCase: XCTestCase, Sendable {
         try await super.setUp()
         continueAfterFailure = false
         app = XCUIApplication()
-        if studyBundleUrl == nil {
-            try FileManager.default.createDirectory(at: Self.tempDir, withIntermediateDirectories: true)
-            studyBundleUrl = try export(to: Self.tempDir, as: .archive)
-        }
+        try FileManager.default.createDirectory(at: Self.tempDir, withIntermediateDirectories: true)
+        studyBundleUrl = try MHCStudyDefinitionExporter::export(to: Self.tempDir, as: .package)
     }
     
     override func tearDown() async throws {
@@ -55,6 +53,7 @@ class MHCTestCase: XCTestCase, Sendable {
         app.terminate()
         app = nil
         appLocale = nil
+        try FileManager.default.removeItem(at: studyBundleUrl)
     }
     
     override class func tearDown() {
@@ -73,21 +72,25 @@ class MHCTestCase: XCTestCase, Sendable {
     /// - parameter extraLaunchArgs: Additional arguments that will be appended to the app's launch arguments. `nil` values will be skipped.
     func launchAppAndEnrollIntoStudy( // swiftlint:disable:this function_body_length
         skip: Bool = false,
-        locale: Locale = .enUS,
+        locale: consuming Locale = .enUS,
         enableDebugMode: Bool = false,
         testEnvironmentConfig: SetupTestEnvironmentConfig = .init(resetExistingData: true, loginAndEnroll: .enable(.default)),
         enableHealthRecords: Bool = MHCTestCase.enableHealthRecords,
         skipHealthPermissionsHandling: Bool = false,
         skipGoingToHomeTab: Bool = false,
         promptedActionsFilter: PromptedActionsFilter = .only([]),
+        triggerConsentRenewalIfNeverSigned: Bool = false,
         heightEntryUnitOverride: LaunchOptions.HeightInputUnitOverride = .none,
         weightEntryUnitOverride: LaunchOptions.WeightInputUnitOverride = .none,
+        extraLaunchOptions: [any _AnyExtraLaunchOption] = [],
         extraLaunchArgs: [String?] = [],
         extraEnvironmentEntries: [String: String] = [:]
     ) throws {
         if skip {
             throw XCTSkip()
         }
+        // note: we're intentionally just setting it here, and then using `appLocale` everywhere else.
+        appLocale = consume locale
         app.launchArguments = Array {
             "--useFirebaseEmulator"
             testEnvironmentConfig.launchOptionArgs(for: .setupTestEnvironment)
@@ -98,12 +101,13 @@ class MHCTestCase: XCTestCase, Sendable {
             heightEntryUnitOverride.launchOptionArgs(for: .heightInputUnitOverride)
             weightEntryUnitOverride.launchOptionArgs(for: .weightInputUnitOverride)
             promptedActionsFilter.launchOptionArgs(for: .promptedActionsFilter)
+            triggerConsentRenewalIfNeverSigned.launchOptionArgs(for: .triggerConsentRenewalIfNeverSigned)
         }
+        app.launchArguments += extraLaunchOptions.flatMap(\.rawArgs)
         app.launchArguments += extraLaunchArgs.compactMap(\.self)
-        appLocale = locale
         app.launchArguments += [
-            "-AppleLanguages", "(\(locale.language.minimalIdentifier))",
-            "-AppleLocale", try XCTUnwrap(LocalizationKey(locale: locale)).description
+            "-AppleLanguages", "(\(appLocale.language.minimalIdentifier))",
+            "-AppleLocale", try XCTUnwrap(LocalizationKey(locale: appLocale)).description
         ]
         app.launchEnvironment["MHC_IS_BEING_UI_TESTED"] = "1"
         app.launchEnvironment.merge(extraEnvironmentEntries, using: .override)
@@ -119,6 +123,10 @@ class MHCTestCase: XCTestCase, Sendable {
             }
             print(msg)
         }
+        XCTAssertFalse(
+            app.launchArguments.contains { $0.contains("'") },
+            "XCUIApplication.launchArguments doesn't support single quote chars within launch arguments (see FB23653577)"
+        )
         app.launch()
         XCTAssert(app.wait(for: .runningForeground, timeout: 2))
         if !skipHealthPermissionsHandling {
@@ -146,6 +154,27 @@ class MHCTestCase: XCTestCase, Sendable {
 
 
 extension MHCTestCase {
+    protocol _AnyExtraLaunchOption { // swiftlint:disable:this type_name
+        var rawArgs: [String] { get }
+    }
+    
+    struct LaunchOptionValue<T: LaunchOptionEncodable>: _AnyExtraLaunchOption {
+        private let option: LaunchOption<T>
+        private let value: T
+        
+        init(_ value: T, for option: LaunchOption<T>) {
+            self.option = option
+            self.value = value
+        }
+        
+        var rawArgs: [String] {
+            value.launchOptionArgs(for: option)
+        }
+    }
+}
+
+
+extension MHCTestCase {
     enum RootLevelTab: String, CaseIterable {
         // needs to be kept in sync with the titles in the app
         case home = "Home"
@@ -166,6 +195,12 @@ extension MHCTestCase {
         let button = app.navigationBars.buttons["MHC:YourAccount"]
         XCTAssert(button.waitForExistence(timeout: 1))
         button.tap()
+    }
+    
+    func closeAccountSheet() {
+        let sheet = app.otherElements["MHC:AccountSheet"]
+        XCTAssert(sheet.waitForExistence(timeout: 2))
+        sheet.navigationBars.buttons["Close"].tap()
     }
 }
 


### PR DESCRIPTION
# skip consent in onboarding if possible; test renewal

## :recycle: Current situation & Problem
- we currently always have the user fill out the consent, even if they've already supplied a signatue for the same revision (of the consent)
- we currently don't test the consent renewal flow

closes #172 
closes #66


## :gear: Release Notes
- new: onboarding will skip the consent if the user already signed it and there have been no material changes since.


## :books: Documentation
n/a


## :white_check_mark: Testing
yes!


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
