### PR TITLE
try to fix a testing race condition

### DIFF
--- a/MyHeartCounts/Modules/SetupTestEnvironment.swift
+++ b/MyHeartCounts/Modules/SetupTestEnvironment.swift
@@ -153,7 +153,7 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
         do {
             try localStorage.deleteAll()
         } catch {
-            try await Task.sleep(for: .seconds(1))
+            try await Task.sleep(for: .seconds(2))
             try localStorage.deleteAll()
         }
     }

--- a/MyHeartCounts/Modules/SetupTestEnvironment.swift
+++ b/MyHeartCounts/Modules/SetupTestEnvironment.swift
@@ -127,7 +127,6 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
     
     private func resetExistingData() async throws {
         logger.notice("Resetting existing data")
-        try localStorage.deleteAll()
         try await bulkHealthExporter.deleteSessionRestorationInfo(for: .mhcHistoricalDataExport)
         try fileUploader.clearPendingUploads()
         LocalPreferencesStore.standard.removeAllEntries(in: .app)
@@ -149,6 +148,13 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
             } catch FirebaseAccountError.notSignedIn {
                 // ok
             }
+        }
+        try await Task.sleep(for: .seconds(0.5))
+        do {
+            try localStorage.deleteAll()
+        } catch {
+            try await Task.sleep(for: .seconds(1))
+            try localStorage.deleteAll()
         }
     }
     

--- a/MyHeartCounts/Modules/SetupTestEnvironment.swift
+++ b/MyHeartCounts/Modules/SetupTestEnvironment.swift
@@ -129,14 +129,6 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
         logger.notice("Resetting existing data")
         try await bulkHealthExporter.deleteSessionRestorationInfo(for: .mhcHistoricalDataExport)
         try fileUploader.clearPendingUploads()
-        LocalPreferencesStore.standard.removeAllEntries(in: .app)
-        switch config.loginAndEnroll {
-        case .skip:
-            break
-        case .enable:
-            // we set this here already to prevent the onboarding sheet from popping up
-            LocalPreferencesStore.standard[.onboardingFlowComplete] = true
-        }
         if let studyManager {
             for enrollment in studyManager.studyEnrollments {
                 try await studyManager.unenroll(from: enrollment)
@@ -148,6 +140,14 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
             } catch FirebaseAccountError.notSignedIn {
                 // ok
             }
+        }
+        LocalPreferencesStore.standard.removeAllEntries(in: .app)
+        switch config.loginAndEnroll {
+        case .skip:
+            break
+        case .enable:
+            // we set this here already to prevent the onboarding sheet from popping up
+            LocalPreferencesStore.standard[.onboardingFlowComplete] = true
         }
         try await Task.sleep(for: .seconds(0.5))
         do {


### PR DESCRIPTION
# try to fix a testing race condition

## :recycle: Current situation & Problem
issue: now that we isolate the individual test runs, and log the user created by run N-1 out before logging run N's user in, we have the the SetupTestEnvironment module's `resetExistingData()` function run a lot more.
there is a potential race condition when deleting the local storage, as the user log out will trigger SpeziFirebase to update its locally-cached account details, which appears to be able to interfere with the localStorage reset call (i think; since this is a race condition it's difficult to reproduce reliably and verify. in either case, moving the call back is a good idea.)


## :gear: Release Notes
- improved test reliability


## :books: Documentation
n/a


## :white_check_mark: Testing
yes

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
