### PR TITLE
"Update Health Conditions" button; Vo2Max; LDL tile fixes

### DIFF
--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1306,8 +1306,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SchmiedmayerLab/Spezi.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.1.6;
+				kind = exactVersion;
+				version = 0.1.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/MyHeartCounts/Account/AccountSheet.swift
+++ b/MyHeartCounts/Account/AccountSheet.swift
@@ -179,6 +179,7 @@ struct AccountSheet: View {
             .foregroundStyle(.textLabel)
         }
         PostTrialNudgesToggle()
+        UpdateComorbiditiesButton()
         NavigationLink("Review Consent Forms") {
             SignedConsentForms()
         }

--- a/MyHeartCounts/Account/Demographics/DemographicsData.swift
+++ b/MyHeartCounts/Account/Demographics/DemographicsData.swift
@@ -122,6 +122,14 @@ final class DemographicsData {
         populate(from: account.details ?? AccountDetails())
     }
     
+    /// Populates the instance, unless it already has been populated before.
+    func populateIfEmpty(from account: Account) {
+        guard self.account == nil else {
+            return
+        }
+        populate(from: account)
+    }
+    
     private func populate(from details: AccountDetails) {
         shouldHandleUpdates = false
         defer {

--- a/MyHeartCounts/Account/UpdateComorbiditiesButton.swift
+++ b/MyHeartCounts/Account/UpdateComorbiditiesButton.swift
@@ -6,7 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
+import SFSafeSymbols
 import SpeziAccount
+import SpeziViews
 import SwiftUI
 
 
@@ -16,6 +18,7 @@ struct UpdateComorbiditiesButton: View {
     
     @State private var showSheet = false
     @State private var demographicsData = DemographicsData()
+    @State private var viewState: ViewState = .idle
     
     var body: some View {
         Button {
@@ -48,22 +51,21 @@ struct UpdateComorbiditiesButton: View {
     }
     
     @ViewBuilder private var closeSheetButton: some View {
-        // look into using an AsyncButton here
         if #available(iOS 26, *) {
-            Button(role: .confirm) {
-                closeSheet()
+            AsyncButton(role: .confirm, state: $viewState) {
+                try await closeSheet()
+            } label: {
+                Label("Done", systemSymbol: .checkmark)
             }
         } else {
-            Button("Done") {
-                closeSheet()
+            AsyncButton("Done", state: $viewState) {
+                try await closeSheet()
             }
         }
     }
     
-    private func closeSheet() {
+    private func closeSheet() async throws {
         showSheet = false
-        Task {
-            try? await demographicsData.flush()
-        }
+        try await demographicsData.flush()
     }
 }

--- a/MyHeartCounts/Account/UpdateComorbiditiesButton.swift
+++ b/MyHeartCounts/Account/UpdateComorbiditiesButton.swift
@@ -32,9 +32,6 @@ struct UpdateComorbiditiesButton: View {
             }
         }
         .disabled(account.details == nil)
-        .task {
-            demographicsData.populateIfEmpty(from: account)
-        }
         .sheet(isPresented: $showSheet) {
             @Bindable var data = demographicsData
             NavigationStack {
@@ -46,6 +43,9 @@ struct UpdateComorbiditiesButton: View {
                             closeSheetButton
                         }
                     }
+            }
+            .onAppear {
+                demographicsData.populateIfEmpty(from: account)
             }
         }
     }

--- a/MyHeartCounts/Account/UpdateComorbiditiesButton.swift
+++ b/MyHeartCounts/Account/UpdateComorbiditiesButton.swift
@@ -1,0 +1,69 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziAccount
+import SwiftUI
+
+
+struct UpdateComorbiditiesButton: View {
+    @Environment(Account.self)
+    private var account
+    
+    @State private var showSheet = false
+    @State private var demographicsData = DemographicsData()
+    
+    var body: some View {
+        Button {
+            showSheet = true
+        } label: {
+            HStack {
+                Text("UPDATE_COMORBIDITIES_BUTTON_TITLE")
+                    .foregroundStyle(.textLabel)
+                Spacer()
+                DisclosureIndicator()
+            }
+        }
+        .disabled(account.details == nil)
+        .task {
+            demographicsData.populateIfEmpty(from: account)
+        }
+        .sheet(isPresented: $showSheet) {
+            @Bindable var data = demographicsData
+            NavigationStack {
+                ComorbiditiesPicker(selection: $data[\.comorbidities].withDefault(Comorbidities()))
+                    .navigationBarTitleDisplayMode(.inline)
+                    .interactiveDismissDisabled()
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            closeSheetButton
+                        }
+                    }
+            }
+        }
+    }
+    
+    @ViewBuilder private var closeSheetButton: some View {
+        // look into using an AsyncButton here
+        if #available(iOS 26, *) {
+            Button(role: .confirm) {
+                closeSheet()
+            }
+        } else {
+            Button("Done") {
+                closeSheet()
+            }
+        }
+    }
+    
+    private func closeSheet() {
+        showSheet = false
+        Task {
+            try? await demographicsData.flush()
+        }
+    }
+}

--- a/MyHeartCounts/Heart Health Dashboard/CVHScore.swift
+++ b/MyHeartCounts/Heart Health Dashboard/CVHScore.swift
@@ -400,12 +400,15 @@ extension ScoreDefinition {
         ])
     }()
     
+    /// LDL Cholesterol
     static let cvhBloodLipids = ScoreDefinition(default: 0, scoringBands: [
-        .inRange(..<130, score: 1, explainer: "< 130"),
-        .inRange(130..<160, score: 0.6, explainer: "130 – 159"),
-        .inRange(160..<190, score: 0.4, explainer: "160 – 189"),
-        .inRange(190..<220, score: 0.2, explainer: "190 – 219"),
-        .inRange(220..., score: 0, explainer: "220+")
+        .inRange(..<56, score: 1, explainer: "< 55"),
+        .inRange(56..<70, score: 0.9, explainer: "56 – 69"),
+        .inRange(70..<100, score: 0.8, explainer: "70 – 99"),
+        .inRange(100..<130, score: 0.6, explainer: "100 – 129"),
+        .inRange(130..<160, score: 0.4, explainer: "130 – 159"),
+        .inRange(160..<190, score: 0.2, explainer: "160 – 189"),
+        .inRange(190..., score: 0, explainer: "190+")
     ])
     
     static let cvhBloodGlucose = ScoreDefinition(default: 0, scoringBands: [

--- a/MyHeartCounts/Heart Health Dashboard/PastTimedWalkTestResultInfo.swift
+++ b/MyHeartCounts/Heart Health Dashboard/PastTimedWalkTestResultInfo.swift
@@ -1,0 +1,39 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SpeziStudyDefinition
+import SwiftUI
+
+
+struct TimedWalkRunTestResultInfo: View {
+    let result: TimedWalkingTestResult
+    
+    var body: some View {
+        LabeledContent("Date", value: result.startDate, format: .dateTime)
+        LabeledContent("Steps", value: result.numberOfSteps, format: .number)
+        LabeledContent(
+            "Distance",
+            value: Measurement<UnitLength>(value: result.distanceCovered, unit: .meters),
+            format: .measurement(width: .abbreviated)
+        )
+        switch result.test.kind {
+        case .walking:
+            let _ = () // swiftlint:disable:this redundant_discardable_let
+        case .running:
+            LabeledContent(
+                "VO2MAX_ESTIMATE_LABEL",
+                value: Measurement<UnitOxygenConsumption>(
+                    value: (result.distanceCovered - 504.9) / 44.73,
+                    unit: .mlPerKgPerMin
+                ),
+                format: .measurement(width: .abbreviated, usage: .asProvided, numberFormatStyle: .number.precision(.fractionLength(...1)))
+            )
+        }
+    }
+}

--- a/MyHeartCounts/Heart Health Dashboard/PastTimedWalkTestResults.swift
+++ b/MyHeartCounts/Heart Health Dashboard/PastTimedWalkTestResults.swift
@@ -70,14 +70,7 @@ struct PastTimedWalkTestResults: View {
     @ViewBuilder
     private func makeDetailsView(for result: TimedWalkingTestResult) -> some View {
         Form {
-            LabeledContent("Start", value: result.startDate, format: .dateTime)
-            LabeledContent("End", value: result.endDate, format: .dateTime)
-            LabeledContent("Number of Steps", value: result.numberOfSteps, format: .number)
-            LabeledContent(
-                "Distance",
-                value: Measurement<UnitLength>(value: result.distanceCovered, unit: .meters),
-                format: .measurement(width: .abbreviated)
-            )
+            TimedWalkRunTestResultInfo(result: result)
         }
         .navigationTitle(result.test.displayTitle.localizedString())
         .navigationBarTitleDisplayMode(.inline)

--- a/MyHeartCounts/Modules/SetupTestEnvironment.swift
+++ b/MyHeartCounts/Modules/SetupTestEnvironment.swift
@@ -159,7 +159,7 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
     }
     
     
-    private func loginAndEnroll( // swiftlint:disable:this function_body_length
+    private func loginAndEnroll( // swiftlint:disable:this function_body_length cyclomatic_complexity
         _ credentials: SetupTestEnvironmentConfig.Credentials
     ) async throws {
         logger.notice("Logging in and enrolling into Study using credentials \(String(describing: credentials))")

--- a/MyHeartCounts/Modules/SetupTestEnvironment.swift
+++ b/MyHeartCounts/Modules/SetupTestEnvironment.swift
@@ -245,7 +245,16 @@ final class SetupTestEnvironment: Module, EnvironmentAccessible, Sendable {
                 newDetails.weightInKG = 67
                 newDetails.raceEthnicity = .white
                 newDetails.latinoStatus = LatinoStatusOption.options[0]
-                newDetails.comorbidities = Comorbidities()
+                newDetails.comorbidities = { () -> Comorbidities in
+                    var value = Comorbidities()
+                    guard let heartFailureOption = Comorbidities.Comorbidity.primaryComorbidities.first(where: {
+                        $0.title.localizedString(for: .enUS).contains("Heart Failure")
+                    }) else {
+                        return value
+                    }
+                    value[heartFailureOption] = .selected(startDate: DateComponents())
+                    return value
+                }()
                 newDetails.usRegion = .dc
                 newDetails.householdIncomeUS = HouseholdIncomeUS.options[0]
                 newDetails.educationUS = EducationStatusUS.options[0]

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -485,10 +485,10 @@
     "< 7" : {
       "shouldTranslate" : false
     },
-    "< 85" : {
-      "shouldTranslate" : false
+    "< 55" : {
+
     },
-    "< 130" : {
+    "< 85" : {
       "shouldTranslate" : false
     },
     "<120 / <80" : {
@@ -753,8 +753,14 @@
     "30 – 59" : {
       "shouldTranslate" : false
     },
+    "56 – 69" : {
+
+    },
     "60 – 89" : {
       "shouldTranslate" : false
+    },
+    "70 – 99" : {
+
     },
     "85 – 99" : {
       "shouldTranslate" : false
@@ -768,6 +774,9 @@
     "100 – 109" : {
       "shouldTranslate" : false
     },
+    "100 – 129" : {
+
+    },
     "110 – 125" : {
       "shouldTranslate" : false
     },
@@ -780,8 +789,8 @@
     "126 – 140" : {
       "shouldTranslate" : false
     },
-    "130 – 159" : {
-      "shouldTranslate" : false
+    "130 – 159" : {
+
     },
     "130–139 / 90–99" : {
       "shouldTranslate" : false
@@ -795,11 +804,8 @@
     "160 – 189" : {
       "shouldTranslate" : false
     },
-    "190 – 219" : {
-      "shouldTranslate" : false
-    },
-    "220+" : {
-      "shouldTranslate" : false
+    "190+" : {
+
     },
     "Abdominal Aortic Aneurysm" : {
       "localizations" : {

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -2311,22 +2311,6 @@
         }
       }
     },
-    "Disclosure Indicator" : {
-      "localizations" : {
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disclosure Indicator"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indicador de Divulgación"
-          }
-        }
-      }
-    },
     "Distance" : {
       "localizations" : {
         "en-GB" : {

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -2737,22 +2737,6 @@
         }
       }
     },
-    "End" : {
-      "localizations" : {
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "End"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizar"
-          }
-        }
-      }
-    },
     "England (%@)" : {
       "localizations" : {
         "en-GB" : {
@@ -5900,22 +5884,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Notifícame"
-          }
-        }
-      }
-    },
-    "Number of Steps" : {
-      "localizations" : {
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Number of Steps"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Número de pasos"
           }
         }
       }

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -9421,6 +9421,28 @@
         }
       }
     },
+    "UPDATE_COMORBIDITIES_BUTTON_TITLE" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update Health Conditions"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update Health Conditions"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar afecciones médicas"
+          }
+        }
+      }
+    },
     "US State / Region" : {
       "localizations" : {
         "en-GB" : {

--- a/MyHeartCounts/Resources/Localizable.xcstrings
+++ b/MyHeartCounts/Resources/Localizable.xcstrings
@@ -9591,6 +9591,28 @@
         }
       }
     },
+    "VO2MAX_ESTIMATE_LABEL" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VO₂ max (estimate)"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VO₂ max (estimate)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "VO₂ máx. (estimación)"
+          }
+        }
+      }
+    },
     "Vocational Training" : {
       "localizations" : {
         "en-GB" : {

--- a/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestView.swift
+++ b/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestView.swift
@@ -197,21 +197,7 @@ private struct TimedWalkingTestView: View {
     @ViewBuilder private var resultsSection: some View {
         if !testIsRunning, let result = mostRecentResult {
             Section("Test Complete") {
-                LabeledContent("Date", value: result.startDate, format: .dateTime)
-                LabeledContent("Steps", value: result.numberOfSteps, format: .number)
-                LabeledContent(
-                    "Distance",
-                    value: Measurement<UnitLength>(value: result.distanceCovered, unit: .meters),
-                    format: .measurement(width: .abbreviated)
-                )
-                LabeledContent(
-                    "VO2MAX_ESTIMATE_LABEL",
-                    value: Measurement<UnitOxygenConsumption>(
-                        value: (result.distanceCovered - 504.9) / 44.73,
-                        unit: .mlPerKgPerMin
-                    ),
-                    format: .measurement(width: .abbreviated, usage: .asProvided, numberFormatStyle: .number.precision(.fractionLength(...1)))
-                )
+                TimedWalkRunTestResultInfo(result: result)
             }
         }
     }

--- a/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestView.swift
+++ b/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestView.swift
@@ -204,6 +204,14 @@ private struct TimedWalkingTestView: View {
                     value: Measurement<UnitLength>(value: result.distanceCovered, unit: .meters),
                     format: .measurement(width: .abbreviated)
                 )
+                LabeledContent(
+                    "VO2MAX_ESTIMATE_LABEL",
+                    value: Measurement<UnitOxygenConsumption>(
+                        value: (result.distanceCovered - 504.9) / 44.73,
+                        unit: .mlPerKgPerMin
+                    ),
+                    format: .measurement(width: .abbreviated, usage: .asProvided, numberFormatStyle: .number.precision(.fractionLength(...1)))
+                )
             }
         }
     }

--- a/MyHeartCounts/Utils/DisclosureIndicator.swift
+++ b/MyHeartCounts/Utils/DisclosureIndicator.swift
@@ -19,7 +19,7 @@ struct DisclosureIndicator: View {
             .foregroundStyle(Color.disclosureIndicator)
             .font(Font(UIFont.preferredFont(forTextStyle: .emphasizedBody) as CTFont))
             .imageScale(.small)
-            .accessibilityLabel("Disclosure Indicator")
+            .accessibilityHidden(true)
     }
 }
 

--- a/MyHeartCounts/Utils/UnitOxygenConsumption.swift
+++ b/MyHeartCounts/Utils/UnitOxygenConsumption.swift
@@ -1,0 +1,21 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+final class UnitOxygenConsumption: Dimension, @unchecked Sendable {
+    static let mlPerKgPerMin = UnitOxygenConsumption(
+        symbol: "mL/kg·min",
+        converter: UnitConverterLinear(coefficient: 1)
+    )
+    
+    override class func baseUnit() -> UnitOxygenConsumption {
+        mlPerKgPerMin
+    }
+}

--- a/MyHeartCountsShared/Package.swift
+++ b/MyHeartCountsShared/Package.swift
@@ -11,7 +11,7 @@ import PackageDescription
 
 
 var packageDeps: [Package.Dependency] = [
-    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", .upToNextMinor(from: "0.1.1")),
+    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", exact: "0.1.1"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.93.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
 ]

--- a/MyHeartCountsShared/Package.swift
+++ b/MyHeartCountsShared/Package.swift
@@ -11,7 +11,7 @@ import PackageDescription
 
 
 var packageDeps: [Package.Dependency] = [
-    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", exact: "0.1.1"),
+    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", exact: "0.1.6"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.93.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
 ]

--- a/MyHeartCountsUITests/ConsentTests.swift
+++ b/MyHeartCountsUITests/ConsentTests.swift
@@ -194,7 +194,7 @@ final class ConsentTests: MHCTestCase, Sendable {
                 skipGoingToHomeTab: true
             )
             // the study bundle now contains a new consent version than what was signed before, which we expect to trigger the renewal flow.
-            XCTAssert(app.otherElements["MHC:ConsentRenewalFlow"].waitForExistence(timeout: 7))
+            XCTAssert(app.otherElements["MHC:ConsentRenewalFlow"].waitForExistence(timeout: 10))
             XCTAssert(app.staticTexts["Consent Renewal"].exists)
             app.buttons["Continue"].tap()
             
@@ -203,7 +203,7 @@ final class ConsentTests: MHCTestCase, Sendable {
                 expectedName: PersonNameComponents(givenName: "Leland", familyName: "Stanford"),
                 signUpForExtraTrial: false
             )
-            XCTAssert(app.otherElements["MHC:ConsentRenewalFlow"].waitForNonExistence(timeout: 7))
+            XCTAssert(app.otherElements["MHC:ConsentRenewalFlow"].waitForNonExistence(timeout: 10))
             // verify that the user is now recorded as having signed the new version
             XCTAssertEqual(try XCTUnwrap(determineLastSignedConsentVersion()), nextConsentVersion)
             app.terminate()

--- a/MyHeartCountsUITests/MHCTestCase.swift
+++ b/MyHeartCountsUITests/MHCTestCase.swift
@@ -183,7 +183,7 @@ class MHCTestCase: XCTestCase, Sendable {
             }
             likelyHasUndecidedPermissions = false
         }
-        if !skipGoingToHomeTab {
+        if !skipGoingToHomeTab && !(testEnvironmentConfig == .init(resetExistingData: true, loginAndEnroll: .skip)) {
             XCTAssert(app.tabBars.element.waitForExistence(timeout: 10))
             goToTab(.home)
             XCTAssert(app.staticTexts["My Heart Counts"].waitForExistence(timeout: 1))

--- a/MyHeartCountsUITests/OnboardingNavigator.swift
+++ b/MyHeartCountsUITests/OnboardingNavigator.swift
@@ -319,7 +319,6 @@ struct OnboardingNavigator { // swiftlint:disable:this type_body_length
     private func navigateDemographics() {
         let navigator = DemographicsNavigator(testCase: testCase)
         navigator.fillInDemographics()
-        
         let continueButton = app.buttons["Continue"]
         while !continueButton.exists {
             app.swipeUp()

--- a/MyHeartCountsUITests/OtherTests.swift
+++ b/MyHeartCountsUITests/OtherTests.swift
@@ -59,4 +59,35 @@ final class OtherTests: MHCTestCase, Sendable {
         )
         XCTAssert(app.staticTexts["Completed"].waitForExistence(timeout: 7))
     }
+    
+    
+    func testUpdateComorbidities() throws {
+        let credentials: SetupTestEnvironmentConfig.Credentials = .random()
+        try launchAppAndEnrollIntoStudy(
+            testEnvironmentConfig: .init(resetExistingData: true, loginAndEnroll: .skip)
+        )
+        do {
+            let navigator = OnboardingNavigator(testCase: self)
+            try navigator.navigateFullOnboardingFlow(
+                region: try XCTUnwrap(appLocale.region),
+                name: .init(givenName: "Leland", familyName: "Stanford"),
+                credentials: credentials,
+                signUpForExtraTrial: false,
+                consentPresenceCheck: .dontCare
+            )
+        }
+        try launchAppAndEnrollIntoStudy(testEnvironmentConfig: .init(resetExistingData: false, loginAndEnroll: .enable(credentials)))
+        openAccountSheet()
+        app.swipeUp()
+        app.buttons["Update Health Conditions"].tap()
+        XCTAssert(app.buttons["Heart Failure, Selected"].waitForExistence(timeout: 4))
+        app.buttons["Diabetes"].tap()
+        app.navigationBars["Diabetes"].buttons["Done"].tap()
+        XCTAssert(app.buttons["Diabetes, Selected"].waitForExistence(timeout: 4))
+        app.navigationBars.buttons["Done"].tap()
+        sleep(for: .seconds(2)) // give it time to sync
+        app.buttons["Update Health Conditions"].tap()
+        XCTAssert(app.buttons["Heart Failure, Selected"].waitForExistence(timeout: 4))
+        XCTAssert(app.buttons["Diabetes, Selected"].waitForExistence(timeout: 4))
+    }
 }

--- a/MyHeartCountsUITests/OtherTests.swift
+++ b/MyHeartCountsUITests/OtherTests.swift
@@ -63,6 +63,7 @@ final class OtherTests: MHCTestCase, Sendable {
     
     func testUpdateComorbidities() throws {
         let credentials: SetupTestEnvironmentConfig.Credentials = .random()
+        try supplyHealthCharacteristics()
         try launchAppAndEnrollIntoStudy(
             testEnvironmentConfig: .init(resetExistingData: true, loginAndEnroll: .skip)
         )

--- a/MyHeartCountsUITests/TaskHandlingTests.swift
+++ b/MyHeartCountsUITests/TaskHandlingTests.swift
@@ -6,55 +6,11 @@
 // SPDX-License-Identifier: MIT
 //
 
-import HealthKit
-import SpeziFoundation
 import XCTest
-import XCTestExtensions
 import XCTHealthKit
 
 
 final class TaskHandlingTests: MHCTestCase, Sendable {
-    private var timedWalkTestDistance: String {
-        switch appLocale.measurementSystem {
-        case .us:
-            "2,762 ft"
-        default:
-            "842 m"
-        }
-    }
-    
-    
-    // also tests the Timed Walk Test UI
-    func testCompleteScheduledTaskViaAlwaysAvailableMenu() throws {
-        try launchAppAndEnrollIntoStudy()
-        goToTab(.upcoming)
-        
-        let completionMessage = app.collectionViews.staticTexts["Six-Minute Walk Test, Completed"]
-        
-        do {
-            var numTries = 0
-            while numTries < 10, !app.collectionViews.buttons["Take Test: Six-Minute Walk Test"].waitForExistence(timeout: 2) {
-                app.swipeUp()
-                numTries += 1
-            }
-        }
-        XCTAssert(app.collectionViews.buttons["Take Test: Six-Minute Walk Test"].waitForExistence(timeout: 2))
-        XCTAssertFalse(completionMessage.exists)
-        
-        app.navigationBars["Tasks"].buttons["Perform Always Available Task"].tap()
-        XCTAssert(app.buttons["Six-Minute Walk Test"].waitForExistence(timeout: 2))
-        app.buttons["Six-Minute Walk Test"].tap()
-        XCTAssert(app.buttons["Start Test"].waitForExistence(timeout: 2))
-        app.buttons["Start Test"].tap()
-        handleMotionAndFitnessAccessPrompt(timeout: .seconds(2))
-        XCTAssert(app.staticTexts["Test Complete"].waitForExistence(timeout: 15))
-        XCTAssert(app.staticTexts["Steps, 624"].exists)
-        XCTAssert(app.staticTexts["Distance, \(timedWalkTestDistance)"].exists)
-        app.navigationBars.buttons["Close"].tap()
-        XCTAssert(completionMessage.exists)
-    }
-    
-    
     func testECG() throws {
         try launchAppAndEnrollIntoStudy()
         goToTab(.upcoming)
@@ -79,62 +35,6 @@ final class TaskHandlingTests: MHCTestCase, Sendable {
     }
     
     
-    func testHHDPastTimedWalkTests() throws {
-        try launchAppAndEnrollIntoStudy()
-        goToTab(.heartHealth)
-        app.swipeUp()
-        app.swipeUp()
-        app.swipeUp()
-        app.staticTexts["Past Timed Walk/Run Test Results"].tap()
-        sleep(for: .seconds(1))
-        
-        let testCellPred = NSPredicate(format: "label LIKE 'Six-Minute Walk Test, *'")
-        var numTests: Int {
-            app.buttons.matching(testCellPred).count
-        }
-        let numTestsBefore = numTests
-        
-        if case let button = app.buttons.element(matching: testCellPred),
-           button.waitForExistence(timeout: 2) {
-            button.firstMatch.tap()
-            XCTAssert(app.navigationBars["Six-Minute Walk Test"].waitForExistence(timeout: 2))
-            XCTAssert(app.staticTexts["Number of Steps, 624"].waitForExistence(timeout: 2))
-            XCTAssert(app.staticTexts["Distance, \(timedWalkTestDistance)"].waitForExistence(timeout: 2))
-            app.navigationBars["Six-Minute Walk Test"].buttons["BackButton"].tap()
-        }
-        
-        app.buttons["Six-Minute Walk Test"].tap()
-        
-        app.buttons["Start Test"].tap()
-        handleMotionAndFitnessAccessPrompt(timeout: .seconds(2))
-        XCTAssert(app.staticTexts["Test Complete"].waitForExistence(timeout: 10))
-        XCTAssert(app.staticTexts["Steps, 624"].exists)
-        XCTAssert(app.staticTexts["Distance, \(timedWalkTestDistance)"].exists)
-        app.otherElements["MHC.TimedWalkTestView"].navigationBars.buttons["Close"].tap()
-        let numTestsAfter = numTests
-        XCTAssertEqual(numTestsAfter, numTestsBefore + 1)
-    }
-    
-    
-    func testRecoverTimedWalkTest() throws {
-        try launchAppAndEnrollIntoStudy()
-        goToTab(.upcoming)
-        
-        app.navigationBars["Tasks"].buttons["Perform Always Available Task"].tap()
-        XCTAssert(app.buttons["Six-Minute Walk Test"].waitForExistence(timeout: 2))
-        app.buttons["Six-Minute Walk Test"].tap()
-        XCTAssert(app.buttons["Start Test"].waitForExistence(timeout: 2))
-        app.buttons["Start Test"].tap()
-        handleMotionAndFitnessAccessPrompt(timeout: .seconds(2))
-        XCTAssert(app.staticTexts["Your 6-Minute Walk Test is in progress."].waitForExistence(timeout: 5))
-        app.terminate()
-        try launchAppAndEnrollIntoStudy(
-            skipGoingToHomeTab: true
-        )
-        XCTAssert(app.staticTexts["Your 6-Minute Walk Test is in progress."].waitForExistence(timeout: 5))
-    }
-    
-    
     func testHomeTabTaskSheetLifetime() throws {
         try launchAppAndEnrollIntoStudy()
         goToTab(.home)
@@ -149,20 +49,5 @@ final class TaskHandlingTests: MHCTestCase, Sendable {
         app.activate()
         XCTAssert(app.wait(for: .runningForeground, timeout: 2))
         XCTAssert(dietIntroTextElement.waitForExistence(timeout: 2))
-    }
-}
-
-
-extension MHCTestCase {
-    func handleMotionAndFitnessAccessPrompt(timeout: Duration) {
-        let app = XCUIApplication.springboard
-        let alert = app.alerts.element(matching: "label LIKE %@", "“*” would like to access your Motion & Fitness activity.")
-        if alert.waitForExistence(timeout: timeout.timeInterval) {
-            // wait a little longer. sometimes the "exists" above resolves to true while the alert is still being presented,
-            // in which case the tap is a little too early and doesn't actually get registered.
-            let allowButton = alert.buttons["Allow"]
-            XCTAssert(allowButton.wait(for: \.isHittable, toEqual: true, timeout: 5))
-            allowButton.tap()
-        }
     }
 }

--- a/MyHeartCountsUITests/TimedWalkTestTests.swift
+++ b/MyHeartCountsUITests/TimedWalkTestTests.swift
@@ -1,0 +1,154 @@
+//
+// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import MyHeartCountsShared
+import SpeziFoundation
+import XCTest
+
+
+final class TimedWalkTestTests: MHCTestCase {
+    private enum WalkRunTestKind: String {
+        case sixMWT = "Six-Minute Walk Test"
+        case twelveMRT = "12-Minute Run Test"
+    }
+    
+    
+    private var timedWalkTestDistance: String {
+        switch appLocale.measurementSystem {
+        case .us:
+            "2,762 ft"
+        default:
+            "842 m"
+        }
+    }
+    
+    
+    /// Tests the siz minute walk test, and the display of past tests.
+    func test6MWT() throws {
+        try _testTimedWalkRunTest(kind: .sixMWT)
+    }
+    
+    
+    /// Tests the 12 minute run test, and the display of past tests.
+    func test12MRT() throws {
+        try _testTimedWalkRunTest(kind: .twelveMRT)
+    }
+    
+    
+    // also tests the Timed Walk Test UI
+    func testCompleteScheduledTaskViaAlwaysAvailableMenu() throws {
+        try launchAppAndEnrollIntoStudy()
+        goToTab(.upcoming)
+        
+        let completionMessage = app.collectionViews.staticTexts["Six-Minute Walk Test, Completed"]
+        
+        do {
+            var numTries = 0
+            while numTries < 10, !app.collectionViews.buttons["Take Test: Six-Minute Walk Test"].waitForExistence(timeout: 2) {
+                app.swipeUp()
+                numTries += 1
+            }
+        }
+        XCTAssert(app.collectionViews.buttons["Take Test: Six-Minute Walk Test"].waitForExistence(timeout: 2))
+        XCTAssertFalse(completionMessage.exists)
+        
+        app.navigationBars["Tasks"].buttons["Perform Always Available Task"].tap()
+        XCTAssert(app.buttons["Six-Minute Walk Test"].waitForExistence(timeout: 2))
+        app.buttons["Six-Minute Walk Test"].tap()
+        XCTAssert(app.buttons["Start Test"].waitForExistence(timeout: 2))
+        app.buttons["Start Test"].tap()
+        handleMotionAndFitnessAccessPrompt(timeout: .seconds(2))
+        XCTAssert(app.staticTexts["Test Complete"].waitForExistence(timeout: 15))
+        XCTAssert(app.staticTexts["Steps, 624"].exists)
+        XCTAssert(app.staticTexts["Distance, \(timedWalkTestDistance)"].exists)
+        app.navigationBars.buttons["Close"].tap()
+        XCTAssert(completionMessage.exists)
+    }
+    
+    
+    private func _testTimedWalkRunTest(kind: WalkRunTestKind) throws {
+        try launchAppAndEnrollIntoStudy()
+        goToTab(.heartHealth)
+        app.swipeUp()
+        app.swipeUp()
+        app.swipeUp()
+        app.staticTexts["Past Timed Walk/Run Test Results"].tap()
+        sleep(for: .seconds(1))
+        
+        let testCellPred = NSPredicate(format: "label LIKE '\(kind.rawValue), *'")
+        var numTests: Int {
+            app.buttons.matching(testCellPred).count
+        }
+        let numTestsBefore = numTests
+        
+        let assertTestDetails = { [self] in
+            XCTAssert(app.staticTexts["Steps, 624"].waitForExistence(timeout: 2))
+            XCTAssert(app.staticTexts["Distance, \(timedWalkTestDistance)"].waitForExistence(timeout: 2))
+            let vo2MaxLabel = app.staticTexts["VO₂ max (estimate), 7.5 mL/kg·min"]
+            switch kind {
+            case .sixMWT:
+                XCTAssertFalse(vo2MaxLabel.exists)
+            case .twelveMRT:
+                XCTAssert(vo2MaxLabel.exists)
+            }
+        }
+        
+        if case let button = app.buttons.element(matching: testCellPred),
+           button.waitForExistence(timeout: 2) {
+            button.firstMatch.tap()
+            XCTAssert(app.navigationBars[kind.rawValue].waitForExistence(timeout: 2))
+            assertTestDetails()
+            app.navigationBars[kind.rawValue].buttons["BackButton"].tap()
+        }
+        
+        app.buttons[kind.rawValue].tap()
+        app.swipeUp()
+        app.buttons["Start Test"].tap()
+        handleMotionAndFitnessAccessPrompt(timeout: .seconds(2))
+        XCTAssert(app.staticTexts["Test Complete"].waitForExistence(timeout: 10))
+        assertTestDetails()
+        app.otherElements["MHC.TimedWalkTestView"].navigationBars.buttons["Close"].tap()
+        let numTestsAfter = numTests
+        XCTAssertEqual(numTestsAfter, numTestsBefore + 1)
+    }
+    
+    
+    func testRecoverTimedWalkTest() throws {
+        try launchAppAndEnrollIntoStudy()
+        goToTab(.upcoming)
+        
+        app.navigationBars["Tasks"].buttons["Perform Always Available Task"].tap()
+        XCTAssert(app.buttons["Six-Minute Walk Test"].waitForExistence(timeout: 2))
+        app.buttons["Six-Minute Walk Test"].tap()
+        XCTAssert(app.buttons["Start Test"].waitForExistence(timeout: 2))
+        app.buttons["Start Test"].tap()
+        handleMotionAndFitnessAccessPrompt(timeout: .seconds(2))
+        XCTAssert(app.staticTexts["Your 6-Minute Walk Test is in progress."].waitForExistence(timeout: 5))
+        app.terminate()
+        try launchAppAndEnrollIntoStudy(
+            skipGoingToHomeTab: true
+        )
+        XCTAssert(app.staticTexts["Your 6-Minute Walk Test is in progress."].waitForExistence(timeout: 5))
+    }
+}
+
+
+extension MHCTestCase {
+    func handleMotionAndFitnessAccessPrompt(timeout: Duration) {
+        let app = XCUIApplication.springboard
+        let alert = app.alerts.element(matching: "label LIKE %@", "“*” would like to access your Motion & Fitness activity.")
+        if alert.waitForExistence(timeout: timeout.timeInterval) {
+            // wait a little longer. sometimes the "exists" above resolves to true while the alert is still being presented,
+            // in which case the tap is a little too early and doesn't actually get registered.
+            let allowButton = alert.buttons["Allow"]
+            XCTAssert(allowButton.wait(for: \.isHittable, toEqual: true, timeout: 5))
+            allowButton.tap()
+        }
+    }
+}


### PR DESCRIPTION
### :recycle: Current situation & Problem
- we currently only allow the participant to enter their preexisting conditions / comoirbidities / health conditions once, a the start when they first enroll into the study (in the onboarding), and we don't allow them to update or modify them afterwards
- we don't surface VO2Max for timed walk/run tests


### :gear: Release Notes
- added an "Update Health Conditions" button to the account sheet
- added VO2Max estimation to 12MWT
- fixed LDL cholesterol scoring bands
- *todo* updated Glucose/A1c tile in dashboard


### :books: Documentation
n/a


### :white_check_mark: Testing
yes


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
