### PR TITLE
Adopt the Organization Repository Standards

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -21,9 +21,9 @@ coverage:
 comment: false
 
 ignore:
-- ^MyHeartCountsUITests.*
-- ^MyHeartCountsTests.*
-- "MyHeartCounts/SensorKit/**"
-- "MyHeartCounts/Utils/Debug Stuff/**"
-- "MyHeartCountsShared/MyHeartCountsShared/PPGSample+SensorKit.swift"
-- "MyHeartCountsShared/Tests/**"
+  - ^MyHeartCountsUITests.*
+  - ^MyHeartCountsTests.*
+  - "MyHeartCounts/SensorKit/**"
+  - "MyHeartCounts/Utils/Debug Stuff/**"
+  - "MyHeartCountsShared/MyHeartCountsShared/PPGSample+SensorKit.swift"
+  - "MyHeartCountsShared/Tests/**"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,28 +6,20 @@
 # SPDX-License-Identifier: MIT
 #
 
-codecov:
-  branch: main
-  require_ci_to_pass: true
-comment:
-  behavior: default
-  layout: reach,diff,flags,files,footer
-  require_changes: false
 coverage:
-  precision: 2
-  range:
-  - 70.0
-  - 90.0
-  round: up
   status:
-    patch:
-      default:
-        target: auto
-        threshold: 5.0
+    # Never let overall coverage slip; the project is at 70.76% today.
     project:
       default:
         target: auto
-        threshold: 5.0
+        threshold: 0.5%
+    # New code is held above the current project average so coverage climbs.
+    patch:
+      default:
+        target: 80%
+
+comment: false
+
 ignore:
 - ^MyHeartCountsUITests.*
 - ^MyHeartCountsTests.*
@@ -35,10 +27,3 @@ ignore:
 - "MyHeartCounts/Utils/Debug Stuff/**"
 - "MyHeartCountsShared/MyHeartCountsShared/PPGSample+SensorKit.swift"
 - "MyHeartCountsShared/Tests/**"
-parsers:
-  gcov:
-    branch_detection:
-      conditional: true
-      loop: true
-      macro: false
-      method: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+#
+# This source file is part of the My Heart Counts iOS open-source project
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+version: 2
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: "weekly"
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
+  - package-ecosystem: "swift"
+    directory: "/MyHeartCountsShared"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   mhc_app_unit_tests:
     name: App Unit Tests
-    uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild.yml@v0.5
     permissions:
       contents: read
     with:
@@ -31,7 +31,7 @@ jobs:
       artifactname: MHC-App-UnitTests.xcresult
   mhc_app_ui_tests:
     name: App UI Tests
-    uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild-or-fastlane.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild-or-fastlane.yml@v0.5
     permissions:
       contents: read
     with:
@@ -45,7 +45,7 @@ jobs:
 
   # mhc_app_ui_tests:
   #   name: App UI Tests
-  #   uses: SchmiedmayerLab/.github/.github/workflows/firebase-emulators-exec.yml@v0.2
+  #   uses: SchmiedmayerLab/.github/.github/workflows/firebase-emulators-exec.yml@v0.5
   #   permissions:
   #     contents: read
   #   with:
@@ -58,7 +58,7 @@ jobs:
   #     GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
   mhc_utils_unit_tests:
     name: Utils Unit Tests (${{ matrix.platform.name }} ${{ matrix.config }})
-    uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild.yml@v0.5
     permissions:
       contents: read
     strategy:
@@ -79,7 +79,7 @@ jobs:
       artifactname: ${{ format('MHC-Shared-UnitTests-{0}-{1}.xcresult', matrix.platform.name, matrix.config) }}
   mhc_utils_unit_tests_linux:
     name: Utils Unit Tests (Linux ${{ matrix.config }})
-    uses: SchmiedmayerLab/.github/.github/workflows/swift-test.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/swift-test.yml@v0.5
     permissions:
       contents: read
     strategy:
@@ -94,7 +94,7 @@ jobs:
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: [mhc_app_unit_tests, mhc_app_ui_tests, mhc_utils_unit_tests, mhc_utils_unit_tests_linux]
-    uses: SchmiedmayerLab/.github/.github/workflows/coverage.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/coverage.yml@v0.5
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -130,7 +130,7 @@ jobs:
   testflight:
     name: iOS App TestFlight Deployment
     needs: [determineenvironment, vars, test]
-    uses: SchmiedmayerLab/.github/.github/workflows/xcode-deploy.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/xcode-deploy.yml@v0.5
     permissions:
       contents: read
     with:

--- a/.github/workflows/monthly-markdown-link-check.yml
+++ b/.github/workflows/monthly-markdown-link-check.yml
@@ -19,3 +19,4 @@ jobs:
     uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5
     permissions:
       contents: read
+      pull-requests: read

--- a/.github/workflows/monthly-markdown-link-check.yml
+++ b/.github/workflows/monthly-markdown-link-check.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -16,6 +16,6 @@ on:
 jobs:
   markdown_link_check:
     name: Markdown Link Check
-    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   formatreleasenotes:
     name: Format Release Notes
-    uses: SchmiedmayerLab/.github/.github/workflows/format-release-notes.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/format-release-notes.yml@v0.5
     permissions:
       contents: read
     with:

--- a/.github/workflows/repository-standards.yml
+++ b/.github/workflows/repository-standards.yml
@@ -1,0 +1,24 @@
+#
+# This source file is part of the My Heart Counts iOS open-source project
+#
+# SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Repository Standards
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  standards:
+    name: Standards
+    uses: SchmiedmayerLab/.github/.github/workflows/repository-standards.yml@v0.5

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -20,17 +20,17 @@ concurrency:
 jobs:
   reuse_action:
     name: REUSE Compliance Check
-    uses: SchmiedmayerLab/.github/.github/workflows/reuse.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/reuse.yml@v0.5
     permissions:
       contents: read
   swiftlint:
     name: SwiftLint
-    uses: SchmiedmayerLab/.github/.github/workflows/swiftlint.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/swiftlint.yml@v0.5
     permissions:
       contents: read
   periphery:
     name: Periphery
-    uses: SchmiedmayerLab/.github/.github/workflows/periphery.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/periphery.yml@v0.5
     permissions:
       contents: read
     with:
@@ -38,12 +38,12 @@ jobs:
       strict: false
   markdownlinkcheck:
     name: Markdown Link Check
-    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5
     permissions:
       contents: read
   codeql:
     name: CodeQL
-    uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild.yml@v0.2
+    uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild.yml@v0.5
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -41,6 +41,7 @@ jobs:
     uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5
     permissions:
       contents: read
+      pull-requests: read
   codeql:
     name: CodeQL
     uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild.yml@v0.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University
 #

--- a/.gitmodules.license
+++ b/.gitmodules.license
@@ -1,4 +1,4 @@
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2025 Stanford University
 

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University
 #

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University
 #

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University
 #
@@ -8,6 +8,7 @@
 
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
+type: software
 authors:
 - family-names: "Kollmer"
   given-names: "Lukas"
@@ -19,3 +20,6 @@ authors:
   given-names: "Paul"
   orcid: "https://orcid.org/0000-0002-8607-9148"
 title: "My Heart Counts"
+license: MIT
+url: "https://github.com/SchmiedmayerLab/MyHeartCounts-iOS"
+repository-code: "https://github.com/SchmiedmayerLab/MyHeartCounts-iOS"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 <!--
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2025 Stanford University
 
@@ -8,9 +8,7 @@ SPDX-License-Identifier: MIT
 
 -->
 
-My Heart Counts Contributors
-=================================
-
+# My Heart Counts iOS Contributors
 - [Lukas Kollmer](https://github.com/lukaskollmer)
 - [Paul Goldschmidt](https://github.com/PaulGoldschmidt)
 - [Paul Schmiedmayer](https://github.com/PSchmiedmayer)

--- a/MyHeartCounts.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/MyHeartCounts.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>FILEHEADER</key>
 	<string>
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: ___YEAR___ Stanford University
 //

--- a/MyHeartCounts/Account/AccountSetupHeader.swift
+++ b/MyHeartCounts/Account/AccountSetupHeader.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/MyHeartCounts/Account/AccountSheet.swift
+++ b/MyHeartCounts/Account/AccountSheet.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/AccountKeys+HelperProtocols.swift
+++ b/MyHeartCounts/Account/Demographics/AccountKeys+HelperProtocols.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/BiologicalSex.swift
+++ b/MyHeartCounts/Account/Demographics/BiologicalSex.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/Comorbidities.swift
+++ b/MyHeartCounts/Account/Demographics/Comorbidities.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/ComorbiditiesPicker.swift
+++ b/MyHeartCounts/Account/Demographics/ComorbiditiesPicker.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/DemographicsAccountKeys.swift
+++ b/MyHeartCounts/Account/Demographics/DemographicsAccountKeys.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/DemographicsButton.swift
+++ b/MyHeartCounts/Account/Demographics/DemographicsButton.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/DemographicsData.swift
+++ b/MyHeartCounts/Account/Demographics/DemographicsData.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/DemographicsForm.swift
+++ b/MyHeartCounts/Account/Demographics/DemographicsForm.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/DemographicsLayout.swift
+++ b/MyHeartCounts/Account/Demographics/DemographicsLayout.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/DemographicsSingleSelectionValue.swift
+++ b/MyHeartCounts/Account/Demographics/DemographicsSingleSelectionValue.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/EducationStatus.swift
+++ b/MyHeartCounts/Account/Demographics/EducationStatus.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/GenderIdentity.swift
+++ b/MyHeartCounts/Account/Demographics/GenderIdentity.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/HouseholdIncome.swift
+++ b/MyHeartCounts/Account/Demographics/HouseholdIncome.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/LatinoStatus.swift
+++ b/MyHeartCounts/Account/Demographics/LatinoStatus.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/NHSNumber.swift
+++ b/MyHeartCounts/Account/Demographics/NHSNumber.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/NHSNumberTextField.swift
+++ b/MyHeartCounts/Account/Demographics/NHSNumberTextField.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/RaceEthnicity.swift
+++ b/MyHeartCounts/Account/Demographics/RaceEthnicity.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/RaceEthnicityPicker.swift
+++ b/MyHeartCounts/Account/Demographics/RaceEthnicityPicker.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/ReferralSource.swift
+++ b/MyHeartCounts/Account/Demographics/ReferralSource.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/StageOfChange.swift
+++ b/MyHeartCounts/Account/Demographics/StageOfChange.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/StageOfChangePicker.swift
+++ b/MyHeartCounts/Account/Demographics/StageOfChangePicker.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/UKRegion.swift
+++ b/MyHeartCounts/Account/Demographics/UKRegion.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/UKRegionPicker.swift
+++ b/MyHeartCounts/Account/Demographics/UKRegionPicker.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/Demographics/USState.swift
+++ b/MyHeartCounts/Account/Demographics/USState.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/MHCAccountKeys.swift
+++ b/MyHeartCounts/Account/MHCAccountKeys.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/MHCUserNotification.swift
+++ b/MyHeartCounts/Account/MHCUserNotification.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/SignedConsentForms.swift
+++ b/MyHeartCounts/Account/SignedConsentForms.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Account/UpdateComorbiditiesButton.swift
+++ b/MyHeartCounts/Account/UpdateComorbiditiesButton.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Account/VerifyEmailSheet.swift
+++ b/MyHeartCounts/Account/VerifyEmailSheet.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Feedback/FeedbackForm.swift
+++ b/MyHeartCounts/Feedback/FeedbackForm.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Feedback/FeedbackManager.swift
+++ b/MyHeartCounts/Feedback/FeedbackManager.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Health Import/HealthKitSamplesFHIRUploader.swift
+++ b/MyHeartCounts/Health Import/HealthKitSamplesFHIRUploader.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Health Import/HealthObservation.swift
+++ b/MyHeartCounts/Health Import/HealthObservation.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Health Import/HistoricalHealthSamplesExportManager.swift
+++ b/MyHeartCounts/Health Import/HistoricalHealthSamplesExportManager.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Achievements/Achievement.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Achievements/Achievement.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/CVHScore.swift
+++ b/MyHeartCounts/Heart Health Dashboard/CVHScore.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/ChartHighlightRuleMark.swift
+++ b/MyHeartCounts/Heart Health Dashboard/ChartHighlightRuleMark.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/CircularProgressView.swift
+++ b/MyHeartCounts/Heart Health Dashboard/CircularProgressView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Components/Gauge.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Components/Gauge.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Components/ScoreResultGauge.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Components/ScoreResultGauge.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/CustomHealthSample.swift
+++ b/MyHeartCounts/Heart Health Dashboard/CustomHealthSample.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Data Entry/HealthKit+AddSamples.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Data Entry/HealthKit+AddSamples.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Data Entry/HeightInputRow.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Data Entry/HeightInputRow.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Data Entry/QuantityInputRow.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Data Entry/QuantityInputRow.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Data Entry/SaveBMISampleView.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Data Entry/SaveBMISampleView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Data Entry/SaveBloodPressureSampleView.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Data Entry/SaveBloodPressureSampleView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Data Entry/SaveQuantitySampleView.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Data Entry/SaveQuantitySampleView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/DetailedHealthStatsView+ChartTimeRange.swift
+++ b/MyHeartCounts/Heart Health Dashboard/DetailedHealthStatsView+ChartTimeRange.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/DetailedHealthStatsView.swift
+++ b/MyHeartCounts/Heart Health Dashboard/DetailedHealthStatsView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/ChartTimeRangePicker.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/ChartTimeRangePicker.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/DefaultHealthDashboardTile.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/DefaultHealthDashboardTile.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboard+BloodPressure.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboard+BloodPressure.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboard+SleepAnalysis.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboard+SleepAnalysis.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboard.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboard.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardLayout.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardLayout.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardQuantityLabel.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardQuantityLabel.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardTile.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthDashboardTile.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthStatsChart.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/HealthStatsChart.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Health Dashboard/MHCFirestoreQuery.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Health Dashboard/MHCFirestoreQuery.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
+++ b/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboard.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboardTab.swift
+++ b/MyHeartCounts/Heart Health Dashboard/HeartHealthDashboardTab.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/PastTimedWalkTestResultInfo.swift
+++ b/MyHeartCounts/Heart Health Dashboard/PastTimedWalkTestResultInfo.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/PastTimedWalkTestResults.swift
+++ b/MyHeartCounts/Heart Health Dashboard/PastTimedWalkTestResults.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/QuantitySample+FHIR.swift
+++ b/MyHeartCounts/Heart Health Dashboard/QuantitySample+FHIR.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/QuantitySample.swift
+++ b/MyHeartCounts/Heart Health Dashboard/QuantitySample.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/QuantitySamplesQuery.swift
+++ b/MyHeartCounts/Heart Health Dashboard/QuantitySamplesQuery.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Score+ExplainerUI.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Score+ExplainerUI.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/Score.swift
+++ b/MyHeartCounts/Heart Health Dashboard/Score.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Heart Health Dashboard/SleepSessionsQuery.swift
+++ b/MyHeartCounts/Heart Health Dashboard/SleepSessionsQuery.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Home Tab/DailyNudge.swift
+++ b/MyHeartCounts/Home Tab/DailyNudge.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Home Tab/HomeTab.swift
+++ b/MyHeartCounts/Home Tab/HomeTab.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Home Tab/Prompted Actions/MHCPromptedActions.swift
+++ b/MyHeartCounts/Home Tab/Prompted Actions/MHCPromptedActions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Home Tab/Prompted Actions/PromptedAction.swift
+++ b/MyHeartCounts/Home Tab/Prompted Actions/PromptedAction.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Home Tab/Prompted Actions/PromptedActionsDigest.swift
+++ b/MyHeartCounts/Home Tab/Prompted Actions/PromptedActionsDigest.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Home Tab/Prompted Actions/PromptedActionsQuery.swift
+++ b/MyHeartCounts/Home Tab/Prompted Actions/PromptedActionsQuery.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/AccountFeatureFlags.swift
+++ b/MyHeartCounts/Modules/AccountFeatureFlags.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/AppRefresh.swift
+++ b/MyHeartCounts/Modules/AppRefresh.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/AppState.swift
+++ b/MyHeartCounts/Modules/AppState.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Modules/ClinicalRecordPermissions.swift
+++ b/MyHeartCounts/Modules/ClinicalRecordPermissions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Modules/ConsentManager.swift
+++ b/MyHeartCounts/Modules/ConsentManager.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/DeferredConfigLoading.swift
+++ b/MyHeartCounts/Modules/DeferredConfigLoading.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/EnvironmentTracking.swift
+++ b/MyHeartCounts/Modules/EnvironmentTracking.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Modules/FirebaseConfiguration.swift
+++ b/MyHeartCounts/Modules/FirebaseConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/FirebaseFunctions.swift
+++ b/MyHeartCounts/Modules/FirebaseFunctions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Modules/FirestoreCacheCleanup.swift
+++ b/MyHeartCounts/Modules/FirestoreCacheCleanup.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Modules/HealthUploadStaging.swift
+++ b/MyHeartCounts/Modules/HealthUploadStaging.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Modules/HealthUploadStagingUploader.swift
+++ b/MyHeartCounts/Modules/HealthUploadStagingUploader.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Modules/Lifecycle.swift
+++ b/MyHeartCounts/Modules/Lifecycle.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/LocalNotifications.swift
+++ b/MyHeartCounts/Modules/LocalNotifications.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/MHCBackgroundTasks.swift
+++ b/MyHeartCounts/Modules/MHCBackgroundTasks.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/ManagedFileUpload.swift
+++ b/MyHeartCounts/Modules/ManagedFileUpload.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/NewsManager.swift
+++ b/MyHeartCounts/Modules/NewsManager.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/NotificationTracking.swift
+++ b/MyHeartCounts/Modules/NotificationTracking.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/NotificationsManager.swift
+++ b/MyHeartCounts/Modules/NotificationsManager.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/SetupTestEnvironment.swift
+++ b/MyHeartCounts/Modules/SetupTestEnvironment.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Modules/StudyBundleLoader.swift
+++ b/MyHeartCounts/Modules/StudyBundleLoader.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/MyHeartCounts+Preview.swift
+++ b/MyHeartCounts/MyHeartCounts+Preview.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/MyHeartCounts+Website.swift
+++ b/MyHeartCounts/MyHeartCounts+Website.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/MyHeartCounts.swift
+++ b/MyHeartCounts/MyHeartCounts.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/MyHeartCountsDelegate.swift
+++ b/MyHeartCounts/MyHeartCountsDelegate.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/MyHeartCountsStandard+Consent.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+Consent.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/MyHeartCountsStandard+CurrentEnrollmentInfo.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+CurrentEnrollmentInfo.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/MyHeartCountsStandard+Notifications.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+Notifications.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/MyHeartCountsStandard+QuestionnaireResponse.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+QuestionnaireResponse.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/MyHeartCountsStandard.swift
+++ b/MyHeartCounts/MyHeartCountsStandard.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/News Tab/Article.swift
+++ b/MyHeartCounts/News Tab/Article.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/News Tab/ArticleCard.swift
+++ b/MyHeartCounts/News Tab/ArticleCard.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/News Tab/ArticleSheet.swift
+++ b/MyHeartCounts/News Tab/ArticleSheet.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/News Tab/NewsTab.swift
+++ b/MyHeartCounts/News Tab/NewsTab.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/AccountOnboarding.swift
+++ b/MyHeartCounts/Onboarding/AccountOnboarding.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/ComprehensionScreening.swift
+++ b/MyHeartCounts/Onboarding/ComprehensionScreening.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Consent+MHC.swift
+++ b/MyHeartCounts/Onboarding/Consent+MHC.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Consent.swift
+++ b/MyHeartCounts/Onboarding/Consent.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/ConsentDisclaimers.swift
+++ b/MyHeartCounts/Onboarding/ConsentDisclaimers.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Onboarding/ConsentRenewal/ConsentRenewalFlow.swift
+++ b/MyHeartCounts/Onboarding/ConsentRenewal/ConsentRenewalFlow.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/DemographicsStep.swift
+++ b/MyHeartCounts/Onboarding/DemographicsStep.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/EligibilityScreening.swift
+++ b/MyHeartCounts/Onboarding/EligibilityScreening.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/FinalEnrollmentStep.swift
+++ b/MyHeartCounts/Onboarding/FinalEnrollmentStep.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/HealthKitPermissions.swift
+++ b/MyHeartCounts/Onboarding/HealthKitPermissions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/HealthRecordPermissions.swift
+++ b/MyHeartCounts/Onboarding/HealthRecordPermissions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/NotificationPermissions.swift
+++ b/MyHeartCounts/Onboarding/NotificationPermissions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/OnboardingDisclaimerStep.swift
+++ b/MyHeartCounts/Onboarding/OnboardingDisclaimerStep.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/OnboardingFlow.swift
+++ b/MyHeartCounts/Onboarding/OnboardingFlow.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/ProgressTracking.swift
+++ b/MyHeartCounts/Onboarding/ProgressTracking.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/ReusableViews/OnboardingHeader.swift
+++ b/MyHeartCounts/Onboarding/ReusableViews/OnboardingHeader.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/ReusableViews/OnboardingIconGridRow.swift
+++ b/MyHeartCounts/Onboarding/ReusableViews/OnboardingIconGridRow.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/ReusableViews/OnboardingLearnMore.swift
+++ b/MyHeartCounts/Onboarding/ReusableViews/OnboardingLearnMore.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/ReusableViews/OnboardingPage.swift
+++ b/MyHeartCounts/Onboarding/ReusableViews/OnboardingPage.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Screening/Components/AgeAtLeast.swift
+++ b/MyHeartCounts/Onboarding/Screening/Components/AgeAtLeast.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Screening/Components/IsFromRegion.swift
+++ b/MyHeartCounts/Onboarding/Screening/Components/IsFromRegion.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Screening/Components/IsUsingSharedAppleID.swift
+++ b/MyHeartCounts/Onboarding/Screening/Components/IsUsingSharedAppleID.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Screening/Components/SpeaksLanguage.swift
+++ b/MyHeartCounts/Onboarding/Screening/Components/SpeaksLanguage.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Screening/NotEligibleView.swift
+++ b/MyHeartCounts/Onboarding/Screening/NotEligibleView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Screening/RegionComingSoon.swift
+++ b/MyHeartCounts/Onboarding/Screening/RegionComingSoon.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Screening/ScreeningDataCollection.swift
+++ b/MyHeartCounts/Onboarding/Screening/ScreeningDataCollection.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Screening/SingleChoiceScreeningComponent.swift
+++ b/MyHeartCounts/Onboarding/Screening/SingleChoiceScreeningComponent.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Screening/SinglePageScreening.swift
+++ b/MyHeartCounts/Onboarding/Screening/SinglePageScreening.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/USRegionPicker.swift
+++ b/MyHeartCounts/Onboarding/USRegionPicker.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/UnableToLoadStudyDefinitionStep.swift
+++ b/MyHeartCounts/Onboarding/UnableToLoadStudyDefinitionStep.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/Welcome.swift
+++ b/MyHeartCounts/Onboarding/Welcome.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/WorkoutPreferenceSetting+Types.swift
+++ b/MyHeartCounts/Onboarding/WorkoutPreferenceSetting+Types.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Onboarding/WorkoutPreferenceSetting.swift
+++ b/MyHeartCounts/Onboarding/WorkoutPreferenceSetting.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/QuestionnaireParsing/QuestionnaireDataExtractor.swift
+++ b/MyHeartCounts/QuestionnaireParsing/QuestionnaireDataExtractor.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Resources/Localizable.xcstrings.license
+++ b/MyHeartCounts/Resources/Localizable.xcstrings.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University
 

--- a/MyHeartCounts/Root View/FullScreenProgressView.swift
+++ b/MyHeartCounts/Root View/FullScreenProgressView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Root View/RootView.swift
+++ b/MyHeartCounts/Root View/RootView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Root View/RootViewTab.swift
+++ b/MyHeartCounts/Root View/RootViewTab.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/Accelerometer+CSV.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/Accelerometer+CSV.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/AmbientLight+CSV.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/AmbientLight+CSV.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/AmbientPressure+CSV.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/AmbientPressure+CSV.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/DeviceUsage+FHIR.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/DeviceUsage+FHIR.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/ECG+FHIR.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/ECG+FHIR.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/HeartRate+CSV.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/HeartRate+CSV.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/OnWristEvent+FHIR.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/OnWristEvent+FHIR.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/PPG+File.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/PPG+File.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/Pedometer+CSV.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/Pedometer+CSV.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/Visit+FHIR.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/Visit+FHIR.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/Sample Types/WristTemp+CSV.swift
+++ b/MyHeartCounts/SensorKit/Sample Types/WristTemp+CSV.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorAccessPermissions.swift
+++ b/MyHeartCounts/SensorKit/SensorAccessPermissions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKit+Extensions.swift
+++ b/MyHeartCounts/SensorKit/SensorKit+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitButton.swift
+++ b/MyHeartCounts/SensorKit/SensorKitButton.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitCodingSystem.swift
+++ b/MyHeartCounts/SensorKit/SensorKitCodingSystem.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+Base.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+Base.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+CSV1.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+CSV1.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+CSV2.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+CSV2.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+FHIR.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+FHIR.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+JSON.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+JSON.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitFHIRExtensions.swift
+++ b/MyHeartCounts/SensorKit/SensorKitFHIRExtensions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SensorKit/SensorKitSampleIDHasher.swift
+++ b/MyHeartCounts/SensorKit/SensorKitSampleIDHasher.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/SharedContext/FeatureFlags.swift
+++ b/MyHeartCounts/SharedContext/FeatureFlags.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/MyHeartCounts/SharedContext/Preferences.swift
+++ b/MyHeartCounts/SharedContext/Preferences.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/MyHeartCounts/SharedContext/Screenshotting.swift
+++ b/MyHeartCounts/SharedContext/Screenshotting.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Supporting Files/GoogleService-Info.plist.license
+++ b/MyHeartCounts/Supporting Files/GoogleService-Info.plist.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University
 

--- a/MyHeartCounts/Supporting Files/Info.plist.license
+++ b/MyHeartCounts/Supporting Files/Info.plist.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2025 Stanford University
 

--- a/MyHeartCounts/Supporting Files/InfoPlist.xcstrings.license
+++ b/MyHeartCounts/Supporting Files/InfoPlist.xcstrings.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2025 Stanford University
 

--- a/MyHeartCounts/Supporting Files/MyHeartCounts.entitlements.license
+++ b/MyHeartCounts/Supporting Files/MyHeartCounts.entitlements.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University
 

--- a/MyHeartCounts/Task Handling/Active Tasks/ECG/ECGInstructions.swift
+++ b/MyHeartCounts/Task Handling/Active Tasks/ECG/ECGInstructions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTest.swift
+++ b/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTest.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestResult+FHIR.swift
+++ b/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestResult+FHIR.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestResult.swift
+++ b/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestResult.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestView.swift
+++ b/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/TimedWalkingTestView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/WatchConnection.swift
+++ b/MyHeartCounts/Task Handling/Active Tasks/Timed Walk Test/WatchConnection.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Task Handling/AlwaysAvailableTaskActions.swift
+++ b/MyHeartCounts/Task Handling/AlwaysAvailableTaskActions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Task Handling/AlwaysAvailableTaskActionsMenu.swift
+++ b/MyHeartCounts/Task Handling/AlwaysAvailableTaskActionsMenu.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Task Handling/PerformTaskAnchor.swift
+++ b/MyHeartCounts/Task Handling/PerformTaskAnchor.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Task Handling/TaskContinuationAnchor.swift
+++ b/MyHeartCounts/Task Handling/TaskContinuationAnchor.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Upcoming Tasks Tab/MHCTodaysEventsQuery.swift
+++ b/MyHeartCounts/Upcoming Tasks Tab/MHCTodaysEventsQuery.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Upcoming Tasks Tab/MissedEventQuery.swift
+++ b/MyHeartCounts/Upcoming Tasks Tab/MissedEventQuery.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Upcoming Tasks Tab/TasksList.swift
+++ b/MyHeartCounts/Upcoming Tasks Tab/TasksList.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Upcoming Tasks Tab/UpcomingTasksTab.swift
+++ b/MyHeartCounts/Upcoming Tasks Tab/UpcomingTasksTab.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/AccountDetails+Diffing.swift
+++ b/MyHeartCounts/Utils/AccountDetails+Diffing.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/AccountDetails+Utils.swift
+++ b/MyHeartCounts/Utils/AccountDetails+Utils.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/BloodPressureMeasurement.swift
+++ b/MyHeartCounts/Utils/BloodPressureMeasurement.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/CheckForUpdatesButton.swift
+++ b/MyHeartCounts/Utils/CheckForUpdatesButton.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Date+LocalizedDescription.swift
+++ b/MyHeartCounts/Utils/Date+LocalizedDescription.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Debounce.swift
+++ b/MyHeartCounts/Utils/Debounce.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/AXDump.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/AXDump.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/AddSleepSessionsButton.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/AddSleepSessionsButton.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/BackgroundTasks+Tracking.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/BackgroundTasks+Tracking.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/DataProcessingDebugView.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/DataProcessingDebugView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/DebugForm.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/DebugForm.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/DebugRemoteNotificationStuff.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/DebugRemoteNotificationStuff.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/FileBrowser.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/FileBrowser.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/FileUploadInsights.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/FileUploadInsights.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/HealthImporterControlView.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/HealthImporterControlView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/HealthObservationsLocalPersistenceLayerDebugView.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/HealthObservationsLocalPersistenceLayerDebugView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/MemoryUsageIndicator.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/MemoryUsageIndicator.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/NotificationsManagerControlView.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/NotificationsManagerControlView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/SchedulerStats.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/SchedulerStats.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/SensorKitControlView.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/SensorKitControlView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/SensorKitSampleSummaries.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/SensorKitSampleSummaries.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Debug Stuff/SpeziModuleDependencyGraph.swift
+++ b/MyHeartCounts/Utils/Debug Stuff/SpeziModuleDependencyGraph.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Demo/DemoSetup.swift
+++ b/MyHeartCounts/Utils/Demo/DemoSetup.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/DisclosureIndicator.swift
+++ b/MyHeartCounts/Utils/DisclosureIndicator.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Exploration/Module+Observation.swift
+++ b/MyHeartCounts/Utils/Exploration/Module+Observation.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/FHIR/Coding Systems/LOINC.swift
+++ b/MyHeartCounts/Utils/FHIR/Coding Systems/LOINC.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/FHIR/Coding Systems/Spezi.swift
+++ b/MyHeartCounts/Utils/FHIR/Coding Systems/Spezi.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/FHIR/Coding Systems/UCUM.swift
+++ b/MyHeartCounts/Utils/FHIR/Coding Systems/UCUM.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/FHIR/CodingProtocol.swift
+++ b/MyHeartCounts/Utils/FHIR/CodingProtocol.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/FHIR/DomainResource+HKSourceRevision.swift
+++ b/MyHeartCounts/Utils/FHIR/DomainResource+HKSourceRevision.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/FHIR/FHIRResource.swift
+++ b/MyHeartCounts/Utils/FHIR/FHIRResource.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/HealthKit.swift
+++ b/MyHeartCounts/Utils/HealthKit.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/Link2.swift
+++ b/MyHeartCounts/Utils/Link2.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/MakeHashable.swift
+++ b/MyHeartCounts/Utils/MakeHashable.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/MenuIndicator.swift
+++ b/MyHeartCounts/Utils/MenuIndicator.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Range+Date.swift
+++ b/MyHeartCounts/Utils/Range+Date.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/AsyncStreamTracked.swift
+++ b/MyHeartCounts/Utils/SwiftUI/AsyncStreamTracked.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/Binding.swift
+++ b/MyHeartCounts/Utils/SwiftUI/Binding.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/ChartUtils.swift
+++ b/MyHeartCounts/Utils/SwiftUI/ChartUtils.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/CodableColor.swift
+++ b/MyHeartCounts/Utils/SwiftUI/CodableColor.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/LabeledButton.swift
+++ b/MyHeartCounts/Utils/SwiftUI/LabeledButton.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/ListSelectionSheet.swift
+++ b/MyHeartCounts/Utils/SwiftUI/ListSelectionSheet.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/NavigationLink.swift
+++ b/MyHeartCounts/Utils/SwiftUI/NavigationLink.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/OpenSettingsApp.swift
+++ b/MyHeartCounts/Utils/SwiftUI/OpenSettingsApp.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/Other.swift
+++ b/MyHeartCounts/Utils/SwiftUI/Other.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/RootSheetRouting.swift
+++ b/MyHeartCounts/Utils/SwiftUI/RootSheetRouting.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/SpeziInjection.swift
+++ b/MyHeartCounts/Utils/SwiftUI/SpeziInjection.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/TabBarAccessibilityFix.swift
+++ b/MyHeartCounts/Utils/SwiftUI/TabBarAccessibilityFix.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/TextLabelForegroundColor.swift
+++ b/MyHeartCounts/Utils/SwiftUI/TextLabelForegroundColor.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/SwiftUI/ViewFormMatchingBackgroundModifier.swift
+++ b/MyHeartCounts/Utils/SwiftUI/ViewFormMatchingBackgroundModifier.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/TypeErasure.swift
+++ b/MyHeartCounts/Utils/TypeErasure.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/UUID.swift
+++ b/MyHeartCounts/Utils/UUID.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCounts/Utils/UnitOxygenConsumption.swift
+++ b/MyHeartCounts/Utils/UnitOxygenConsumption.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCounts/Utils/Utils.swift
+++ b/MyHeartCounts/Utils/Utils.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/.gitignore
+++ b/MyHeartCountsShared/.gitignore
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2025 Stanford University
 #

--- a/MyHeartCountsShared/Package.swift
+++ b/MyHeartCountsShared/Package.swift
@@ -1,6 +1,6 @@
 // swift-tools-version: 6.2
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/BinaryCodable/BinaryCodable.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/BinaryCodable/BinaryCodable.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/BinaryCodable/BinaryDecoder.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/BinaryCodable/BinaryDecoder.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/BinaryCodable/BinaryEncoder.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/BinaryCodable/BinaryEncoder.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/BinaryCodable/Primitives.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/BinaryCodable/Primitives.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/LaunchOptions.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/LaunchOptions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/Other.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/Other.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/SetupTestEnvironmentConfig.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/SetupTestEnvironmentConfig.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/StudyBundleSelector.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/StudyBundleSelector.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/UnitOverrides.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Launch Options/UnitOverrides.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/LiveActivityAttributes.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/LiveActivityAttributes.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/MyHeartCountsShared.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/MyHeartCountsShared.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/PPGSample+BinaryCodable.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/PPGSample+BinaryCodable.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/PPGSample+SensorKit.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/PPGSample+SensorKit.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/PPGSample.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/PPGSample.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Prompted Actions/PromptedActionID.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Prompted Actions/PromptedActionID.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Prompted Actions/PromptedActionsFilter.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Prompted Actions/PromptedActionsFilter.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/StudyDefinition+Utils.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/StudyDefinition+Utils.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/AnyEncodable.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/AnyEncodable.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/AnyObjectBasedHashableImpl.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/AnyObjectBasedHashableImpl.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/CSVWriter.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/CSVWriter.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Calendar+Extensions.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Calendar+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/ColorMath.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/ColorMath.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Dictionary.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Dictionary.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/FileManager+Compression.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/FileManager+Compression.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/JSONValue.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/JSONValue.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/LocaleUtils.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/LocaleUtils.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Measure.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Measure.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/OSLog.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/OSLog.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/ProcessInfo/Environment.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/ProcessInfo/Environment.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/ProcessInfo/IsProDevice.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/ProcessInfo/IsProDevice.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/ProcessInfo/Memory.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/ProcessInfo/Memory.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Range+Extensions.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Range+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Region+Extensions.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Region+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Set.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Set.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/String+Random.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/String+Random.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Utils.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Utils.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Version+Utils.swift
+++ b/MyHeartCountsShared/Sources/MyHeartCountsShared/Utils/Version+Utils.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Sources/SensorKitCLI/DecodePPG.swift
+++ b/MyHeartCountsShared/Sources/SensorKitCLI/DecodePPG.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Sources/SensorKitCLI/SensorKitCLI.swift
+++ b/MyHeartCountsShared/Sources/SensorKitCLI/SensorKitCLI.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/BinaryCodingTests.swift
+++ b/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/BinaryCodingTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/LaunchOptionsTests.swift
+++ b/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/LaunchOptionsTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/MHCLaunchOptionsTests.swift
+++ b/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/MHCLaunchOptionsTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/PPGBinaryCodingTests.swift
+++ b/MyHeartCountsShared/Tests/MyHeartCountsSharedTests/PPGBinaryCodingTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsTests/HealthSampleProcessingTests.swift
+++ b/MyHeartCountsTests/HealthSampleProcessingTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsTests/NHSNumberTests.swift
+++ b/MyHeartCountsTests/NHSNumberTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsTests/OtherTests.swift
+++ b/MyHeartCountsTests/OtherTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsTests/ScoreCalcTests.swift
+++ b/MyHeartCountsTests/ScoreCalcTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsTests/UtilsTests+DateRange.swift
+++ b/MyHeartCountsTests/UtilsTests+DateRange.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsTests/UtilsTests.swift
+++ b/MyHeartCountsTests/UtilsTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/BasicAppUsage.swift
+++ b/MyHeartCountsUITests/BasicAppUsage.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/ConsentTests.swift
+++ b/MyHeartCountsUITests/ConsentTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsUITests/DemographicsNavigator.swift
+++ b/MyHeartCountsUITests/DemographicsNavigator.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsUITests/HealthDashboardTests.swift
+++ b/MyHeartCountsUITests/HealthDashboardTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/MHCTestCase.swift
+++ b/MyHeartCountsUITests/MHCTestCase.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/OnboardingNavigator.swift
+++ b/MyHeartCountsUITests/OnboardingNavigator.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/OnboardingTests.swift
+++ b/MyHeartCountsUITests/OnboardingTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/OtherTests.swift
+++ b/MyHeartCountsUITests/OtherTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/PromptedActionsTests.swift
+++ b/MyHeartCountsUITests/PromptedActionsTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsUITests/RegressionTests.swift
+++ b/MyHeartCountsUITests/RegressionTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsUITests/Screenshotting/MHCScreenshotting.swift
+++ b/MyHeartCountsUITests/Screenshotting/MHCScreenshotting.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsUITests/StudyParticipationTests.swift
+++ b/MyHeartCountsUITests/StudyParticipationTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/SurveyDataExtraction.swift
+++ b/MyHeartCountsUITests/SurveyDataExtraction.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/TabBarAXStatsTests.swift
+++ b/MyHeartCountsUITests/TabBarAXStatsTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsUITests/TaskHandlingTests.swift
+++ b/MyHeartCountsUITests/TaskHandlingTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsUITests/TimedWalkTestTests.swift
+++ b/MyHeartCountsUITests/TimedWalkTestTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2026 Stanford University
 //

--- a/MyHeartCountsUITests/UITestUtils.swift
+++ b/MyHeartCountsUITests/UITestUtils.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsWatchApp/ContentView.swift
+++ b/MyHeartCountsWatchApp/ContentView.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsWatchApp/MHCWatchApp.swift
+++ b/MyHeartCountsWatchApp/MHCWatchApp.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsWatchApp/MHCWatchAppDelegate.swift
+++ b/MyHeartCountsWatchApp/MHCWatchAppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsWatchApp/MHCWatchAppStandard.swift
+++ b/MyHeartCountsWatchApp/MHCWatchAppStandard.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsWatchApp/PhoneConnection.swift
+++ b/MyHeartCountsWatchApp/PhoneConnection.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/MyHeartCountsWatchApp/Resources/InfoPlist.xcstrings.license
+++ b/MyHeartCountsWatchApp/Resources/InfoPlist.xcstrings.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2025 Stanford University
 

--- a/MyHeartCountsWatchApp/Resources/Localizable.xcstrings.license
+++ b/MyHeartCountsWatchApp/Resources/Localizable.xcstrings.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2025 Stanford University
 

--- a/MyHeartCountsWatchApp/Supporting Files/Info.plist.license
+++ b/MyHeartCountsWatchApp/Supporting Files/Info.plist.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University
 

--- a/MyHeartCountsWatchApp/Supporting Files/MyHeartCountsWatchApp.entitlements.license
+++ b/MyHeartCountsWatchApp/Supporting Files/MyHeartCountsWatchApp.entitlements.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University
 

--- a/MyHeartCountsWatchApp/WorkoutManager.swift
+++ b/MyHeartCountsWatchApp/WorkoutManager.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+// This source file is part of the My Heart Counts iOS open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 <!--
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
-SPDX-FileCopyrightText: 2025 Stanford University
+SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 
 SPDX-License-Identifier: MIT
 
 -->
 
 # My Heart Counts
+
+[![Build and Test](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/actions/workflows/build-and-test.yml)
+[![Deployment](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/actions/workflows/deployment.yml/badge.svg)](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/actions/workflows/deployment.yml)
+[![REUSE status](https://api.reuse.software/badge/github.com/SchmiedmayerLab/MyHeartCounts-iOS)](https://api.reuse.software/info/github.com/SchmiedmayerLab/MyHeartCounts-iOS)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/blob/main/LICENSE.md)
 
 [My Heart Counts (MHC) application](https://myheartcounts.stanford.edu) is a [Spezi](https://github.com/StanfordSpezi)-based large-scale cardiovascular study application, developed at Stanford University.
 
@@ -116,15 +121,21 @@ In order to run and develop the My Heart Counts app locally, you'll need the fol
 > [!NOTE]  
 > Please make sure not to commit and push any of the SensorKit, Code Signing, and run argument changes listed above; these changes are only required for local development.
 
-
 ## Contributing
 
-Contributions to this project are welcome. Please make sure to read the [contribution guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) first.
-
+Contributions to this project are welcome. Please make sure to read the [contribution guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) first. You can find a list of contributors in the [CONTRIBUTORS.md](CONTRIBUTORS.md) file.
 
 ## License
 
-This project is licensed under the MIT License. See [Licenses](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/tree/main/LICENSES) for more information.
+This project is licensed under the MIT License. See [LICENSE.md](LICENSE.md) for more information.
 
-![Stanford and Stanford Medicine logos](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/stanford-footer-light.png#gh-light-mode-only)
-![Stanford and Stanford Medicine logos](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/stanford-footer-dark.png#gh-dark-mode-only)
+## Citation
+
+If you use this software, please cite it using the metadata in [CITATION.cff](CITATION.cff), which GitHub surfaces through the [*Cite this repository*](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) button.
+
+## Our Research
+
+For more information, visit the [Schmiedmayer Lab GitHub organization](https://github.com/SchmiedmayerLab).
+
+![Schmiedmayer Lab](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/footer-light.png#gh-light-mode-only)
+![Schmiedmayer Lab](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/footer-dark.png#gh-dark-mode-only)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
 [![Build and Test](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/actions/workflows/build-and-test.yml)
 [![Deployment](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/actions/workflows/deployment.yml/badge.svg)](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/actions/workflows/deployment.yml)
 [![REUSE status](https://api.reuse.software/badge/github.com/SchmiedmayerLab/MyHeartCounts-iOS)](https://api.reuse.software/info/github.com/SchmiedmayerLab/MyHeartCounts-iOS)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md)
 
 [My Heart Counts (MHC) application](https://myheartcounts.stanford.edu) is a [Spezi](https://github.com/StanfordSpezi)-based large-scale cardiovascular study application, developed at Stanford University.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University
 #

--- a/fastlane/.gitignore
+++ b/fastlane/.gitignore
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University
 #

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,5 @@
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/fastlane/README.md.license
+++ b/fastlane/README.md.license
@@ -1,5 +1,5 @@
 
-This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+This source file is part of the My Heart Counts iOS open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University
 

--- a/make_screenshots
+++ b/make_screenshots
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This source file is part of the My Heart Counts iOS application based on the Stanford Spezi Template Application project
+# This source file is part of the My Heart Counts iOS open-source project
 #
 # SPDX-FileCopyrightText: 2026 Stanford University
 #


### PR DESCRIPTION
### :recycle: Current situation & Problem

`SchmiedmayerLab/.github` defines the organization repository standard in [`REPOSITORY_STANDARDS.md`](https://github.com/SchmiedmayerLab/.github/blob/main/REPOSITORY_STANDARDS.md) and enforces it in `repository-standards.yml`. This repository does not call that workflow yet.

No related issue was identified.

### :gear: Release Notes

- Call `repository-standards.yml@v0.5` from a new `.github/workflows/repository-standards.yml`.
- Pin every shared workflow reference to `v0.5`.
- Complete `CITATION.cff` with the fields Zenodo reads, and bring `CONTRIBUTORS.md` to the documented shape.
- Add the badge block and the Contributing, License, Citation and Our Research sections to the README.
- Group Dependabot updates into a single weekly pull request.
- Name the same project in every SPDX header.

### :books: Documentation

The standard is documented in [`REPOSITORY_STANDARDS.md`](https://github.com/SchmiedmayerLab/.github/blob/main/REPOSITORY_STANDARDS.md).

### :white_check_mark: Testing

- `actionlint`, `yamllint` and `reuse lint`
- `repository-standards.yml@v0.5` runs on this pull request

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).