### PR TITLE
Handle Late Permission Prompts While Waiting for the Home Screen

### DIFF
--- a/MyHeartCountsUITests/MHCTestCase.swift
+++ b/MyHeartCountsUITests/MHCTestCase.swift
@@ -184,7 +184,7 @@ class MHCTestCase: XCTestCase, Sendable {
             likelyHasUndecidedPermissions = false
         }
         if !skipGoingToHomeTab && !(testEnvironmentConfig == .init(resetExistingData: true, loginAndEnroll: .skip)) {
-            XCTAssert(app.tabBars.element.waitForExistence(timeout: 10))
+            XCTAssert(waitForRootLevelTabBar(timeout: 60))
             goToTab(.home)
             XCTAssert(app.staticTexts["My Heart Counts"].waitForExistence(timeout: 1))
             XCTAssert(app.staticTexts["Welcome to My Heart Counts"].exists)
@@ -195,6 +195,25 @@ class MHCTestCase: XCTestCase, Sendable {
                 2
             )
         }
+    }
+    
+    
+    /// Waits for the app to reach its root-level tab bar, answering permission prompts for as long as it waits.
+    ///
+    /// The app requests notification and HealthKit access while it sets up the test environment, and how long that
+    /// takes depends on the machine the tests run on. A prompt that arrives after the fixed budget above is never
+    /// answered, and since it covers the app the tab bar can then never appear.
+    private func waitForRootLevelTabBar(timeout: TimeInterval) -> Bool {
+        let tabBar = app.tabBars.element
+        let deadline = Date.now.addingTimeInterval(timeout)
+        repeat {
+            if tabBar.waitForExistence(timeout: 1) {
+                return true
+            }
+            app.confirmNotificationAuthorization(timeout: 0)
+            app.handleHealthKitAuthorization(timeout: 0)
+        } while Date.now < deadline
+        return tabBar.exists
     }
     
     


### PR DESCRIPTION
### :recycle: Current situation & Problem

`App UI Tests` fails intermittently, and the test that fails changes from run to run — the signature of a problem in the shared launch helper rather than in any one test. In [run 31475897090](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/actions/runs/31475897090) the victim was `ConsentTests.testConsentRenewalNewPatch`, reported as `MHCTestCase.swift:187: XCTAssertTrue failed`.

`launchAppAndEnrollIntoStudy` answers the permission prompts once, with a fixed budget:

```swift
app.confirmNotificationAuthorization()
app.handleHealthKitAuthorization(timeout: 10) // Idea: maybe adjust this based on local vs CI?
```

Both helpers default to *not* requiring their prompt to appear, because most launches inherit permissions granted earlier in the run and get no prompt at all. So when a prompt does come up but arrives late, it is silently skipped — and the very next statement waits 10 s for the tab bar, which can never appear while the unanswered sheet covers the app.

The accessibility snapshots from that run show exactly that sequence. At 06:19:42, when the 10 s HealthKit wait gave up, the app was still showing `Setting Up Test Environment, loginAndEnroll(_:) will ask for regular HK auth`. Eleven seconds later, when the tab-bar wait gave up and the assertion failed, the `Health Access` sheet was on screen and unanswered. How long the app takes to get there depends on how loaded the runner is, so the victim moves around — related to #173.

### :gear: Release Notes

n/a, this only touches the UI test target.

### :books: Documentation

The wait is extracted into `waitForRootLevelTabBar(timeout:)` with a doc comment recording why the prompts are answered inside the wait instead of once before it.

### :white_check_mark: Testing

No test is skipped, relaxed or retried, and no assertion is removed: reaching the home screen is still asserted, and the wait returns as soon as the tab bar exists rather than after a fixed duration. The previous 10 s tab-bar budget is replaced by a 60 s deadline for the app to finish setting up the test environment, which now includes answering a prompt that shows up mid-wait; the observed sheet arrived ~21 s after the app started asking for it.

Verified locally: `swiftlint` is clean on the changed file, and the new helper type-checks against `XCTest` with the `XCTHealthKit` and `XCTSpeziNotifications` signatures it calls. The full suite needs the Firebase emulator and a macOS runner, so it was not run locally — CI on this PR covers it.

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
