### PR TITLE
Load the Study Bundle from the zstd Archive

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,12 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# REUSE and Markdown Links run as part of the Repository Standards workflow.
 jobs:
-  reuse_action:
-    name: REUSE Compliance Check
-    uses: SchmiedmayerLab/.github/.github/workflows/reuse.yml@v0.5
-    permissions:
-      contents: read
   swiftlint:
     name: SwiftLint
     uses: SchmiedmayerLab/.github/.github/workflows/swiftlint.yml@v0.5
@@ -36,12 +32,6 @@ jobs:
     with:
       runsonlabels: '["macOS", "self-hosted"]'
       strict: false
-  markdownlinkcheck:
-    name: Markdown Link Check
-    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5
-    permissions:
-      contents: read
-      pull-requests: read
   codeql:
     name: CodeQL
     uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild.yml@v0.5

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1307,7 +1307,7 @@
 			repositoryURL = "https://github.com/SchmiedmayerLab/Spezi.git";
 			requirement = {
 				kind = revision;
-				revision = 4a1240eff42fca1c94a5f495cfeb9b7e83db26ed;
+				revision = 8ed550bc8c689743250cc493937686fcf6d1350c;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1307,7 +1307,7 @@
 			repositoryURL = "https://github.com/SchmiedmayerLab/Spezi.git";
 			requirement = {
 				kind = revision;
-				revision = 8ed550bc8c689743250cc493937686fcf6d1350c;
+				revision = b610a9a6018bf9fb431d4d483f88aead12d30eff;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1230,8 +1230,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions.git";
 			requirement = {
-				branch = "feature/zstd-study-bundle";
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.2.5;
 			};
 		};
 		805363752DB6997600D7E8A3 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1307,7 +1307,7 @@
 			repositoryURL = "https://github.com/SchmiedmayerLab/Spezi.git";
 			requirement = {
 				kind = revision;
-				revision = b610a9a6018bf9fb431d4d483f88aead12d30eff;
+				revision = 2ce6314add5dce2cfbd0651840b039a53acddcdb;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1234,8 +1234,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.2.3;
+				branch = "feature/zstd-study-bundle";
+				kind = branch;
 			};
 		};
 		805363752DB6997600D7E8A3 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
@@ -1291,7 +1291,7 @@
 			repositoryURL = "https://github.com/apple/FHIRModels.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.8.0;
+				minimumVersion = 0.9.3;
 			};
 		};
 		80BE064E2DCF3A2D00171114 /* XCRemoteSwiftPackageReference "swift-package-list" */ = {
@@ -1306,8 +1306,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SchmiedmayerLab/Spezi.git";
 			requirement = {
-				kind = exactVersion;
-				version = 0.1.6;
+				branch = "feature/study-bundle-archive";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/MyHeartCounts.xcodeproj/project.pbxproj
+++ b/MyHeartCounts.xcodeproj/project.pbxproj
@@ -1306,8 +1306,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SchmiedmayerLab/Spezi.git";
 			requirement = {
-				branch = "feature/study-bundle-archive";
-				kind = branch;
+				kind = revision;
+				revision = 4a1240eff42fca1c94a5f495cfeb9b7e83db26ed;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f724bcc64fafcfed9b9fdfb2e3ee63d129b17cc32ae9026c4e5e96b443642202",
+  "originHash" : "c59e6754f6c5bfac19435d778ead45a30ea3306cb16443c5ea476ad9137f903e",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -133,7 +133,7 @@
       "location" : "https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions.git",
       "state" : {
         "branch" : "feature/zstd-study-bundle",
-        "revision" : "eef6104664be17ce53f38ca4c61e4796a73bacb2"
+        "revision" : "624e60b399f2ebdb0c9b92562abf9e97aba959c9"
       }
     },
     {
@@ -204,7 +204,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SchmiedmayerLab/Spezi.git",
       "state" : {
-        "revision" : "b610a9a6018bf9fb431d4d483f88aead12d30eff"
+        "revision" : "2ce6314add5dce2cfbd0651840b039a53acddcdb"
       }
     },
     {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "aec4e44cb485ad45250e1833612803e1a2ec620c20b2a1e7188353ff8c7e378d",
+  "originHash" : "12abef18b5f8356f27c4e4108bfa2552b584e59a0801f262422d7100d33204f8",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -128,6 +128,15 @@
       }
     },
     {
+      "identity" : "myheartcounts-studydefinitions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions.git",
+      "state" : {
+        "branch" : "feature/zstd-study-bundle",
+        "revision" : "ef084bea0f31332571c6743d120713ac455cc101"
+      }
+    },
+    {
       "identity" : "nanopb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
@@ -188,6 +197,14 @@
       "state" : {
         "revision" : "e01b3d4f861412f8dcee8d93c417d2c2b0cdfd77",
         "version" : "7.0.0"
+      }
+    },
+    {
+      "identity" : "spezi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SchmiedmayerLab/Spezi.git",
+      "state" : {
+        "revision" : "4a1240eff42fca1c94a5f495cfeb9b7e83db26ed"
       }
     },
     {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e055f42655ea0cfd97521bce7715feea3e41f82c28d109dfafe505c69164c57b",
+  "originHash" : "f724bcc64fafcfed9b9fdfb2e3ee63d129b17cc32ae9026c4e5e96b443642202",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -133,7 +133,7 @@
       "location" : "https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions.git",
       "state" : {
         "branch" : "feature/zstd-study-bundle",
-        "revision" : "7ba7a87fc2ffc7fbe9040993fc540dbb715910e9"
+        "revision" : "eef6104664be17ce53f38ca4c61e4796a73bacb2"
       }
     },
     {
@@ -204,7 +204,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SchmiedmayerLab/Spezi.git",
       "state" : {
-        "revision" : "8ed550bc8c689743250cc493937686fcf6d1350c"
+        "revision" : "b610a9a6018bf9fb431d4d483f88aead12d30eff"
       }
     },
     {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "12abef18b5f8356f27c4e4108bfa2552b584e59a0801f262422d7100d33204f8",
+  "originHash" : "e055f42655ea0cfd97521bce7715feea3e41f82c28d109dfafe505c69164c57b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "bb4002485ff867768dec13bf904a2ddb050bd1b1",
-        "version" : "11.3.0"
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "42e81d245e30e49ea6a5830cf2842d44a1591270",
-        "version" : "12.15.0"
+        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
+        "version" : "12.17.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "9bfcc6cf435b2e7c5562c1900b8680c594fa9a64",
-        "version" : "3.6.0"
+        "revision" : "dc39082d8881109d35b94b1c122164c0e8d08a55",
+        "version" : "3.6.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "144855f40d8668927f256a3045f7fdc4c3f4338b",
-        "version" : "12.15.0"
+        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
+        "version" : "12.17.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
-        "version" : "10.1.0"
+        "revision" : "ba3358d3c3dbae8ef230b58a46b97ad65e84e974",
+        "version" : "10.1.1"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "c46e5f8b7c23265f17c24ca7f9fa1b13ded7a822",
-        "version" : "8.1.1"
+        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
+        "version" : "8.1.2"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "c0ac7575d70050c2973ba2318bd5af47f8e8153a",
-        "version" : "5.3.0"
+        "revision" : "724a52eea6329b7e12d3ad8300d76ca9f3895fcc",
+        "version" : "5.3.1"
       }
     },
     {
@@ -133,7 +133,7 @@
       "location" : "https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions.git",
       "state" : {
         "branch" : "feature/zstd-study-bundle",
-        "revision" : "ef084bea0f31332571c6743d120713ac455cc101"
+        "revision" : "7ba7a87fc2ffc7fbe9040993fc540dbb715910e9"
       }
     },
     {
@@ -204,7 +204,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SchmiedmayerLab/Spezi.git",
       "state" : {
-        "revision" : "4a1240eff42fca1c94a5f495cfeb9b7e83db26ed"
+        "revision" : "8ed550bc8c689743250cc493937686fcf6d1350c"
       }
     },
     {
@@ -239,8 +239,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
-        "version" : "1.1.4"
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -284,8 +284,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
-        "version" : "1.14.0"
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
       }
     },
     {
@@ -302,8 +302,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
-        "version" : "2.101.2"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -365,8 +365,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "704705c5c51156ede21172a38654d522ce487074",
+        "version" : "1.8.0"
       }
     },
     {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions.git",
       "state" : {
-        "branch" : "feature/zstd-study-bundle",
-        "revision" : "624e60b399f2ebdb0c9b92562abf9e97aba959c9"
+        "revision" : "06e410c9ded3727296961dc39526aa1c49905538",
+        "version" : "0.2.5"
       }
     },
     {

--- a/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MyHeartCounts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b39f9cf739aa1cf7193f7f9fbe1f935fc550fdcf54e4a7c4fdcfc3f14a737d6b",
+  "originHash" : "aec4e44cb485ad45250e1833612803e1a2ec620c20b2a1e7188353ff8c7e378d",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/FHIRModels.git",
       "state" : {
-        "revision" : "a05392269b630a8d661bda720d149fee2f0257e2",
-        "version" : "0.8.0"
+        "revision" : "3fdead0f6459d7d3480d12c514ae27da31974a41",
+        "version" : "0.9.3"
       }
     },
     {
@@ -110,15 +110,6 @@
       }
     },
     {
-      "identity" : "gzipswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/1024jp/GzipSwift",
-      "state" : {
-        "revision" : "731037f6cc2be2ec01562f6597c1d0aa3fe6fd05",
-        "version" : "6.0.1"
-      }
-    },
-    {
       "identity" : "interop-ios-for-google-sdks",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
@@ -134,33 +125,6 @@
       "state" : {
         "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
         "version" : "1.22.5"
-      }
-    },
-    {
-      "identity" : "mlx-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift.git",
-      "state" : {
-        "revision" : "072b684acaae80b6a463abab3a103732f33774bf",
-        "version" : "0.29.1"
-      }
-    },
-    {
-      "identity" : "mlx-swift-examples",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-examples.git",
-      "state" : {
-        "revision" : "9bff95ca5f0b9e8c021acc4d71a2bbe4a7441631",
-        "version" : "2.29.1"
-      }
-    },
-    {
-      "identity" : "myheartcounts-studydefinitions",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions.git",
-      "state" : {
-        "revision" : "93cc43abca414a1b1675b2829044eb410052212b",
-        "version" : "0.2.3"
       }
     },
     {
@@ -193,10 +157,10 @@
     {
       "identity" : "phonenumberkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/marmelroy/PhoneNumberKit",
+      "location" : "https://github.com/PhoneNumberKit/PhoneNumberKit.git",
       "state" : {
-        "revision" : "169ab10234347fb19b37441f2867ace896a284b0",
-        "version" : "4.3.0"
+        "revision" : "e18a029dbada1d8eb32e3f81a4eb72eba539ff75",
+        "version" : "5.0.6"
       }
     },
     {
@@ -224,15 +188,6 @@
       "state" : {
         "revision" : "e01b3d4f861412f8dcee8d93c417d2c2b0cdfd77",
         "version" : "7.0.0"
-      }
-    },
-    {
-      "identity" : "spezi",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SchmiedmayerLab/Spezi.git",
-      "state" : {
-        "revision" : "5c27bec94adc52737574faaee79bcb5db3ed264d",
-        "version" : "0.1.6"
       }
     },
     {
@@ -299,30 +254,12 @@
       }
     },
     {
-      "identity" : "swift-concurrency-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
-      "state" : {
-        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
-        "version" : "1.4.0"
-      }
-    },
-    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
       "state" : {
         "revision" : "db774a277f60063a32d854f2980299caf06da041",
         "version" : "1.6.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
-        "version" : "2.3.6"
       }
     },
     {
@@ -366,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-generator.git",
       "state" : {
-        "revision" : "d002e5d9a1ac4ff6466bb89ab8fa1c9a0afd820f",
-        "version" : "1.12.2"
+        "revision" : "af9a2a1f5dcfb00a278d4bb29c6d75080932e99e",
+        "version" : "1.13.0"
       }
     },
     {
@@ -416,48 +353,12 @@
       }
     },
     {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers.git",
-      "state" : {
-        "revision" : "a2e184dddb4757bc943e77fbe99ac6786c53f0b2",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins.git",
       "state" : {
         "revision" : "3292bab28e6e92000161348003fdef8edc4e582d",
         "version" : "0.65.0"
-      }
-    },
-    {
-      "identity" : "swiftui-math",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/swiftui-math",
-      "state" : {
-        "revision" : "0b5c2cfaaec8d6193db206f675048eeb5ce95f71",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "textual",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/textual.git",
-      "state" : {
-        "revision" : "5b06b811c0f5313b6b84bbef98c635a630638c38",
-        "version" : "0.3.1"
-      }
-    },
-    {
-      "identity" : "threadlocal",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SchmiedmayerLab/ThreadLocal.git",
-      "state" : {
-        "revision" : "7295e0c1042bb01e72db75b073ebdacb2e50fd41",
-        "version" : "0.1.4"
       }
     },
     {
@@ -481,7 +382,7 @@
     {
       "identity" : "zstd",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordBDHG/zstd.git",
+      "location" : "https://github.com/SchmiedmayerLab/zstd.git",
       "state" : {
         "revision" : "ae9f20ca2716f2605822ca375995b7d876389b64",
         "version" : "1.5.8-beta.1"

--- a/MyHeartCounts/Modules/StudyBundleLoader.swift
+++ b/MyHeartCounts/Modules/StudyBundleLoader.swift
@@ -158,7 +158,7 @@ final class StudyBundleLoader: Module, Sendable {
             if let selector = FeatureFlags.overrideFirebaseConfig ?? LocalPreferencesStore.standard[.lastUsedFirebaseConfig],
                let options = try? DeferredConfigLoading.firebaseOptions(for: selector),
                let bucket = options.storageBucket {
-                studyBundleArchiveUrl = Self.url(ofFile: "mhcStudyBundle.\(StudyBundle.fileExtension).aar", inBucket: bucket)
+                studyBundleArchiveUrl = Self.url(ofFile: "mhcStudyBundle.\(StudyBundle.archiveFileExtension)", inBucket: bucket)
             } else {
                 logger.error("No last-used firebase config.")
                 throw .noLastUsedFirebaseConfig
@@ -167,7 +167,7 @@ final class StudyBundleLoader: Module, Sendable {
             studyBundleArchiveUrl = url
         case .bundledWithApp:
             do {
-                studyBundleArchiveUrl = try export(to: .temporaryDirectory, as: .archive)
+                studyBundleArchiveUrl = try export(to: .temporaryDirectory, as: .zstd)
             } catch {
                 throw .unableToCreateLocalBundle(error)
             }
@@ -198,18 +198,17 @@ final class StudyBundleLoader: Module, Sendable {
     private func openDownloadedStudyBundle(at url: URL) async throws(LoadError) -> StudyBundle {
         let dstUrl = self.studyBundlesUrl.appendingPathComponent(UUID().uuidString, conformingTo: .speziStudyBundle)
         // Can we maybe elide the url -> tmpUrl copy here?(!)
-        let tmpUrl = URL.temporaryDirectory.appending(component: UUID().uuidString).appendingPathExtension("\(StudyBundle.fileExtension).aar")
+        let tmpUrl = URL.temporaryDirectory.appending(component: UUID().uuidString).appendingPathExtension(StudyBundle.archiveFileExtension)
         do {
             try fileManager.copyItem(at: url, to: tmpUrl, overwriteExisting: true)
-            defer {
-                try? fileManager.removeItem(at: tmpUrl)
-            }
-            try fileManager.unarchiveDirectory(at: tmpUrl, to: dstUrl)
         } catch {
             throw .unableToFetchFromServer(error)
         }
+        defer {
+            try? fileManager.removeItem(at: tmpUrl)
+        }
         do {
-            return try StudyBundle(bundleUrl: dstUrl)
+            return try StudyBundle.unarchive(tmpUrl, to: dstUrl)
         } catch {
             logger.error("Error opening StudyBundle: \(error)")
             throw .unableToDecode(error)
@@ -236,8 +235,8 @@ final class StudyBundleLoader: Module, Sendable {
                 // we're given a package-style input, rather than an archive.
                 // we simply turn it into an archive, and pass that url on.
                 let dstUrl: URL = .temporaryDirectory
-                    .appending(component: UUID().uuidString).appendingPathExtension("\(StudyBundle.fileExtension).aar")
-                try fileManager.archiveDirectory(at: url, to: dstUrl)
+                    .appending(component: UUID().uuidString).appendingPathExtension(StudyBundle.archiveFileExtension)
+                try StudyBundle(bundleUrl: url).archive(to: dstUrl)
                 return dstUrl
             } else {
                 throw error
@@ -308,9 +307,9 @@ extension URL {
         guard let values = try? self.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey, .isPackageKey]) else {
             return nil
         }
-        if values.isRegularFile == true, hasExtension("spezistudybundle.aar") {
+        if values.isRegularFile == true, hasExtension(StudyBundle.archiveFileExtension) {
             return .archive
-        } else if values.isDirectory == true, hasExtension("spezistudybundle") {
+        } else if values.isDirectory == true, hasExtension(StudyBundle.fileExtension) {
             return .package
         }
         return nil

--- a/MyHeartCountsShared/Package.swift
+++ b/MyHeartCountsShared/Package.swift
@@ -11,8 +11,8 @@ import PackageDescription
 
 
 var packageDeps: [Package.Dependency] = [
-    // Tracks the study-bundle feature branch until the next Spezi release.
-    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", branch: "feature/study-bundle-archive"),
+    // Pins the study-bundle feature revision until the next Spezi release.
+    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "4a1240eff42fca1c94a5f495cfeb9b7e83db26ed"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.93.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
 ]

--- a/MyHeartCountsShared/Package.swift
+++ b/MyHeartCountsShared/Package.swift
@@ -12,7 +12,7 @@ import PackageDescription
 
 var packageDeps: [Package.Dependency] = [
     // Pins the study-bundle feature revision until the next Spezi release.
-    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "b610a9a6018bf9fb431d4d483f88aead12d30eff"),
+    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "2ce6314add5dce2cfbd0651840b039a53acddcdb"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.93.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
 ]

--- a/MyHeartCountsShared/Package.swift
+++ b/MyHeartCountsShared/Package.swift
@@ -12,7 +12,7 @@ import PackageDescription
 
 var packageDeps: [Package.Dependency] = [
     // Pins the study-bundle feature revision until the next Spezi release.
-    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "4a1240eff42fca1c94a5f495cfeb9b7e83db26ed"),
+    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "8ed550bc8c689743250cc493937686fcf6d1350c"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.93.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
 ]

--- a/MyHeartCountsShared/Package.swift
+++ b/MyHeartCountsShared/Package.swift
@@ -12,7 +12,7 @@ import PackageDescription
 
 var packageDeps: [Package.Dependency] = [
     // Pins the study-bundle feature revision until the next Spezi release.
-    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "8ed550bc8c689743250cc493937686fcf6d1350c"),
+    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "b610a9a6018bf9fb431d4d483f88aead12d30eff"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.93.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
 ]

--- a/MyHeartCountsShared/Package.swift
+++ b/MyHeartCountsShared/Package.swift
@@ -11,7 +11,8 @@ import PackageDescription
 
 
 var packageDeps: [Package.Dependency] = [
-    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", exact: "0.1.6"),
+    // Tracks the study-bundle feature branch until the next Spezi release.
+    .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", branch: "feature/study-bundle-archive"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.93.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0")
 ]


### PR DESCRIPTION
### :recycle: Current situation & Problem

The study bundle pipeline moves to a platform-neutral zstd archive (SchmiedmayerLab/Spezi#44, SchmiedmayerLab/MyHeartCounts-StudyDefinitions#43) so the Android app can consume the same server-driven artifact. The loader still spoke Apple Archive end to end.

### :gear: Release Notes

- `StudyBundleLoader` downloads, unpacks, and locally regenerates the bundle in the zstd archive format: the bucket filename follows `StudyBundle.archiveFileExtension`, the runtime export uses the `zstd` format, and unpacking goes through `StudyBundle.unarchive`. A corrupt download now correctly falls back to the bundled study.
- The Spezi and study definition package references track the study-bundle feature revisions until the releases are tagged; FHIRModels moves to `0.9.3` alongside.

### :books: Documentation

No documentation changes.

### :white_check_mark: Testing

The study definition exporter — including the new `StudyBundle.archive`/`unarchive` stack — builds for the iOS Simulator SDK, and its round-trip is covered on macOS and Linux in the upstream pull requests.

### :warning: Draft

Adopting the new archive API requires the study-bundle Spezi branch, which sits on Spezi `0.2`; the app is still on Spezi `0.1.6`. Building the app therefore first needs the app's own Spezi `0.2` migration (renamed FHIR/HealthKit and ResearchKit products), which is separate from the study bundle and out of scope here. This PR stays a draft, scoped to the loader change, and merges once that migration lands and the upstream releases are tagged.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
