### PR TITLE
properly encode MHC app version into _all_ samples

### DIFF
--- a/MyHeartCounts/Health Import/HealthKitSamplesFHIRUploader.swift
+++ b/MyHeartCounts/Health Import/HealthKitSamplesFHIRUploader.swift
@@ -36,7 +36,9 @@ struct HealthKitSamplesFHIRUploader: BatchProcessor {
     
     private func storeSamples<Sample>(_ samples: consuming [Sample], of sampleType: SampleType<Sample>) throws -> URL {
         let fileManager = FileManager.default
-        let resources = try (consume samples).mapIntoResourceProxies()
+        let resources = try (consume samples).mapIntoResourceProxies(
+            extensions: MyHeartCountsStandard.defaultHealthObservationFHIRExtensions
+        )
         let encoded = try JSONEncoder().encode(consume resources)
         
         let compressed = try (consume encoded).compressed(using: Zstd.self)

--- a/MyHeartCounts/Health Import/HealthObservation.swift
+++ b/MyHeartCounts/Health Import/HealthObservation.swift
@@ -79,11 +79,13 @@ extension HealthObservation {
             case .r4(let inner):
                 if var inner = inner as? any ModelsR4.DomainResource {
                     inner.addSourceRevisionExtensions(for: record.sourceRevision)
+                    inner.addMHCAppRevision()
                     resource = .r4(inner)
                 }
             case .dstu2(let inner):
                 if var inner = inner as? any ModelsDSTU2.DomainResource {
                     inner.addSourceRevisionExtensions(for: record.sourceRevision)
+                    inner.addMHCAppRevision()
                     resource = .dstu2(inner)
                 }
             }

--- a/MyHeartCounts/Heart Health Dashboard/QuantitySample+FHIR.swift
+++ b/MyHeartCounts/Heart Health Dashboard/QuantitySample+FHIR.swift
@@ -54,7 +54,7 @@ extension QuantitySample: HealthObservation {
                 start: self.startDate,
                 end: self.endDate
             )
-            return try sample.resource(withMapping: mapping, issuedDate: issuedDate)
+            return try sample.resource(withMapping: mapping, issuedDate: issuedDate, extensions: extensions)
         case .custom(.bloodLipids):
             let code = "18262-6".asFHIRStringPrimitive() // "Cholesterol in LDL [Mass/volume] in Serum or Plasma by Direct assay"
             let system = "http://loinc.org".asFHIRURIPrimitive()

--- a/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+HealthKit.swift
@@ -94,7 +94,7 @@ extension MyHeartCountsStandard {
     
     
     static let defaultHealthObservationFHIRExtensions: [any FHIRExtensionBuilderProtocol] = [
-        .sampleUploadTimeZone, .mhcStudyRevision
+        .sampleUploadTimeZone, .mhcStudyRevision, .mhcAppRevision
     ]
     
     nonisolated private static let directFirestoreUploadDefaultBatchSize = 100
@@ -327,17 +327,4 @@ extension FHIRExtensionBuilderProtocol where Self == FHIRExtensionBuilder<Void> 
             resource.append(extension: ext, behaviour: .replace)
         }
     }
-    
-    static var mhcAppVersion: Self {
-        .init { resource in
-            try FHIRExtensionBuilder
-                .sourceRevision(url: .mhcAppRevision)
-                .apply(input: .mhc, to: &resource)
-        }
-    }
-}
-
-
-extension FHIRExtensionURL {
-    static let mhcAppRevision = Self("https://bdh.stanford.edu/fhir/defs/mhcAppRevision")
 }

--- a/MyHeartCounts/MyHeartCountsStandard+QuestionnaireResponse.swift
+++ b/MyHeartCounts/MyHeartCountsStandard+QuestionnaireResponse.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import FHIRModelsExtensions
 @preconcurrency import FirebaseFirestore
 import ModelsR4
 import MyHeartCountsShared
@@ -24,6 +25,7 @@ extension MyHeartCountsStandard {
         // shouldn't be necessary, but we had some issues with these not being properly set
         var response = response
         response.questionnaire = questionnaire.url?.value?.url.absoluteString.asFHIRCanonicalPrimitive()
+        response.append(extension: .mhcAppRevision, behaviour: .replace)
         let logger = await self.logger
         let id = response.identifier?.value?.value?.string ?? UUID().uuidString
         do {

--- a/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+Base.swift
+++ b/MyHeartCounts/SensorKit/SensorKitDataFetcher+Uploading+Base.swift
@@ -57,11 +57,11 @@ extension MHCSensorSampleUploadStrategy {
             // for anything above that, we set the size to nil.
             size: Int32(exactly: size).map { FHIRPrimitive(FHIRUnsignedInteger($0)) },
             // NOTE: we use a path relative to this user's storage directory here!
-//            url: FHIRExtensionURL(ManagedFileUpload.Category(sensor).firebasePath).appending(component: url.lastPathComponent).r4
             url: ManagedFileUpload.Category(sensor).firebasePath.appending("/\(url.lastPathComponent)").asFHIRURIPrimitive()
         )
         let reference = DocumentReference(
             content: [.init(attachment: attachment)],
+            extension: [.mhcAppRevision],
             status: FHIRPrimitive(.current)
         )
         var observation = Observation(

--- a/MyHeartCounts/Utils/FHIR/MHCAppRevision.swift
+++ b/MyHeartCounts/Utils/FHIR/MHCAppRevision.swift
@@ -1,0 +1,160 @@
+//
+// This source file is part of the My Heart Counts iOS open-source project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import FHIRModelsExtensions
+import Foundation
+import ModelsDSTU2
+import ModelsR4
+
+
+/// Identifies the My Heart Counts build which created a FHIR resource.
+///
+/// Encoded into every FHIR resource the app uploads, under `FHIRExtensionURL.mhcAppRevision`:
+/// ```json
+/// {
+///   "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision",
+///   "extension": [
+///     { "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision/version", "valueString": "4.2.1" },
+///     { "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision/build", "valueInteger": 123 },
+///     { "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision/bundleIdentifier", "valueString": "edu.stanford.MyHeartCounts" },
+///     { "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision/osVersion", "valueString": "26.5.0" }
+///   ]
+/// }
+/// ```
+///
+/// - Important: This is **not** the same as `FHIRExtensionURL.sourceRevision`. `sourceRevision` identifies the origin of the
+///     underlying *sample* (e.g. the Apple Watch which recorded a heart rate sample, or the health system which supplied a
+///     clinical record), and for HealthKit samples is written by SpeziHealthKitFHIR. This extension always identifies the
+///     My Heart Counts build which performed the conversion into FHIR.
+enum MHCAppRevision {
+    /// A single child of the `FHIRExtensionURL.mhcAppRevision` extension.
+    fileprivate enum Field {
+        case string(component: String, value: String)
+        case integer(component: String, value: Int)
+
+        var url: FHIRExtensionURL {
+            switch self {
+            case .string(let component, _), .integer(let component, _):
+                FHIRExtensionURL.mhcAppRevision.appending(component: component)
+            }
+        }
+    }
+
+    /// The app's marketing version (`CFBundleShortVersionString`), e.g. `"4.2.1"`.
+    static let version: String = Bundle.main.appVersion
+    /// The app's build number (`CFBundleVersion`), e.g. `123`.
+    ///
+    /// `nil` if the value is absent or not an integer, in which case the `build` child extension is omitted.
+    static let build: Int? = Bundle.main.appBuildNumber
+    /// The app's bundle identifier.
+    static let bundleIdentifier: String? = Bundle.main.bundleIdentifier
+    /// The operating system version the resource was created on, e.g. `"26.5.0"`.
+    static let osVersion: String = {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }()
+
+    /// The children of the `FHIRExtensionURL.mhcAppRevision` extension, in a stable order.
+    fileprivate static let fields: [Field] = {
+        var fields: [Field] = [.string(component: "version", value: version)]
+        if let build {
+            fields.append(.integer(component: "build", value: build))
+        }
+        if let bundleIdentifier {
+            fields.append(.string(component: "bundleIdentifier", value: bundleIdentifier))
+        }
+        fields.append(.string(component: "osVersion", value: osVersion))
+        return fields
+    }()
+}
+
+
+extension FHIRExtensionURL {
+    /// Url of a FHIR Extension identifying the My Heart Counts build which created the resource.
+    ///
+    /// See ``MHCAppRevision``.
+    static let mhcAppRevision = Self("https://bdh.stanford.edu/fhir/defs/mhcAppRevision")
+}
+
+
+// MARK: FHIR Encoding
+
+extension ModelsR4.Extension {
+    /// A FHIR Extension identifying the My Heart Counts build which created the resource.
+    ///
+    /// Invariant for the lifetime of the process.
+    static let mhcAppRevision: Self = {
+        let children: [Self] = MHCAppRevision.fields.map { (field: MHCAppRevision.Field) -> Self in
+            switch field {
+            case let .string(_, value):
+                return Self(url: field.url, value: .string(value.asFHIRStringPrimitive()))
+            case let .integer(_, value):
+                return Self(url: field.url, value: .integer(value.asFHIRIntegerPrimitive()))
+            }
+        }
+        return Self(extension: children, url: FHIRExtensionURL.mhcAppRevision)
+    }()
+}
+
+
+extension ModelsDSTU2.Extension {
+    /// A FHIR Extension identifying the My Heart Counts build which created the resource.
+    ///
+    /// Invariant for the lifetime of the process.
+    static let mhcAppRevision: Self = {
+        let children: [Self] = MHCAppRevision.fields.map { (field: MHCAppRevision.Field) -> Self in
+            switch field {
+            case let .string(_, value):
+                return Self(url: field.url.dstu2, value: .string(value.asFHIRStringPrimitive()))
+            case let .integer(_, value):
+                return Self(url: field.url.dstu2, value: .integer(value.asFHIRIntegerPrimitive()))
+            }
+        }
+        return Self(extension: children, url: FHIRExtensionURL.mhcAppRevision.dstu2)
+    }()
+}
+
+
+// MARK: Application
+
+extension FHIRExtensionBuilderProtocol where Self == FHIRExtensionBuilder<Void> {
+    /// A FHIR Extension Builder which writes the ``MHCAppRevision`` into a FHIR resource.
+    ///
+    /// Part of `MyHeartCountsStandard.defaultHealthObservationFHIRExtensions`, i.e. applied to every FHIR resource
+    /// created from a ``HealthObservation``.
+    static var mhcAppRevision: Self {
+        .init { resource in
+            resource.append(extension: .mhcAppRevision, behaviour: .replace)
+        }
+    }
+}
+
+
+extension ModelsR4.DomainResource {
+    /// Writes the ``MHCAppRevision`` into the resource, replacing any already-present `mhcAppRevision` extension.
+    ///
+    /// Exists in addition to the ``FHIRExtensionBuilderProtocol/mhcAppRevision`` extension builder because
+    /// `ModelsR4.DomainResource` (used for the clinical record passthrough) does not conform to `FHIRTypeWithExtensions`.
+    mutating func addMHCAppRevision() {
+        var extensions = self.extension ?? []
+        extensions.removeAll { $0.url == FHIRExtensionURL.mhcAppRevision.r4 }
+        extensions.append(.mhcAppRevision)
+        self.extension = extensions
+    }
+}
+
+
+extension ModelsDSTU2.DomainResource {
+    /// Writes the ``MHCAppRevision`` into the resource, replacing any already-present `mhcAppRevision` extension.
+    mutating func addMHCAppRevision() {
+        var extensions = self.extension ?? []
+        extensions.removeAll { $0.url == FHIRExtensionURL.mhcAppRevision.dstu2 }
+        extensions.append(.mhcAppRevision)
+        self.extension = extensions
+    }
+}

--- a/MyHeartCounts/Utils/FHIR/MHCAppRevision.swift
+++ b/MyHeartCounts/Utils/FHIR/MHCAppRevision.swift
@@ -17,12 +17,12 @@ import ModelsR4
 /// Encoded into every FHIR resource the app uploads, under `FHIRExtensionURL.mhcAppRevision`:
 /// ```json
 /// {
-///   "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision",
+///   "url": "https://myheartcounts.stanford.edu/fhir/core/mhcAppRevision",
 ///   "extension": [
-///     { "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision/version", "valueString": "4.2.1" },
-///     { "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision/build", "valueInteger": 123 },
-///     { "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision/bundleIdentifier", "valueString": "edu.stanford.MyHeartCounts" },
-///     { "url": "https://bdh.stanford.edu/fhir/defs/mhcAppRevision/osVersion", "valueString": "26.5.0" }
+///     { "url": "https://myheartcounts.stanford.edu/fhir/core/mhcAppRevision/version", "valueString": "4.2.1" },
+///     { "url": "https://myheartcounts.stanford.edu/fhir/core/mhcAppRevision/build", "valueInteger": 123 },
+///     { "url": "https://myheartcounts.stanford.edu/fhir/core/mhcAppRevision/bundleIdentifier", "valueString": "edu.stanford.MyHeartCounts" },
+///     { "url": "https://myheartcounts.stanford.edu/fhir/core/mhcAppRevision/osVersion", "valueString": "26.5.0" }
 ///   ]
 /// }
 /// ```
@@ -78,7 +78,7 @@ extension FHIRExtensionURL {
     /// Url of a FHIR Extension identifying the My Heart Counts build which created the resource.
     ///
     /// See ``MHCAppRevision``.
-    static let mhcAppRevision = Self("https://bdh.stanford.edu/fhir/defs/mhcAppRevision")
+    static let mhcAppRevision = Self("https://myheartcounts.stanford.edu/fhir/core/mhcAppRevision")
 }
 
 

--- a/MyHeartCountsTests/HealthSampleProcessingTests.swift
+++ b/MyHeartCountsTests/HealthSampleProcessingTests.swift
@@ -123,7 +123,44 @@ struct HealthSampleProcessingTests {
         }
     }
     
+
+    /// Every FHIR resource the app creates must identify the MHC build which created it.
+    @Test
+    func mhcAppRevisionIsPartOfTheDefaultExtensions() throws {
+        let sample = HKQuantitySample(
+            type: .init(.heartRate),
+            quantity: HKQuantity(unit: .count() / .minute(), doubleValue: 85),
+            start: .now,
+            end: .now
+        )
+        let resource = try sample.resource(extensions: MyHeartCountsStandard.defaultHealthObservationFHIRExtensions)
+        let observation = try #require(resource.get(if: Observation.self))
+        let ext = try #require(observation.extensions(for: FHIRExtensionURL.mhcAppRevision).first)
+        func value(ofChild component: String) throws -> ModelsR4.Extension.ValueX {
+            let url = FHIRExtensionURL.mhcAppRevision.appending(component: component).r4
+            let child = try #require(ext.extension?.first { $0.url == url }, "missing '\(component)' child extension")
+            return try #require(child.value)
+        }
+        guard case .string(let version) = try value(ofChild: "version") else {
+            Issue.record("'version' is not a valueString")
+            return
+        }
+        #expect(version.value?.string == MHCAppRevision.version)
+        guard case .string(let osVersion) = try value(ofChild: "osVersion") else {
+            Issue.record("'osVersion' is not a valueString")
+            return
+        }
+        #expect(osVersion.value?.string == MHCAppRevision.osVersion)
+        if let expectedBuild = MHCAppRevision.build {
+            guard case .integer(let build) = try value(ofChild: "build") else {
+                Issue.record("'build' is not a valueInteger")
+                return
+            }
+            #expect(build.value?.integer == Int32(expectedBuild))
+        }
+    }
     
+
     @Test
     func healthUploadStagingDuplicates() async throws {
         let healthUploadStaging = HealthUploadStaging(persistence: .inMemory)


### PR DESCRIPTION
### :recycle: Current situation & Problem
issue: we currently don't always encode the MHC app version (and build number) into all FHIR samples created by the app.


### :gear: Release Notes
- the app now encodes the app version and build numbers into all FHIR resources it creates, as extension values


### :books: Documentation
n/a (will be mentioned in the data spec, but that's the different repo)


### :white_check_mark: Testing
yea


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
