### PR TITLE
Keep the Project Attributes When Fastlane Writes the Project

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,6 +6,8 @@
 # SPDX-License-Identifier: MIT
 #
 
+require_relative "xcodeproj_patch"
+
 default_platform(:ios)
 
 APP_CONFIG = {

--- a/fastlane/xcodeproj_patch.rb
+++ b/fastlane/xcodeproj_patch.rb
@@ -1,0 +1,30 @@
+#
+# This source file is part of the My Heart Counts iOS open-source project
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+require "xcodeproj"
+
+# Xcodeproj drops attributes it does not know when it writes a project back, and it does not know
+# the traits Xcode records for a package reference or the destination it records for a copy files
+# build phase. Fastlane opens and saves the project to set the bundle identifier and the build
+# number, so a deployment silently removed the package traits and the destination of the phases
+# that embed the watch app and the extensions. Declaring both keeps the round trip lossless.
+#
+# This can be removed once Xcodeproj knows the attributes itself.
+module Xcodeproj
+  class Project
+    module Object
+      class XCRemoteSwiftPackageReference < AbstractObject
+        attribute :traits, Array
+      end
+
+      class PBXCopyFilesBuildPhase < AbstractBuildPhase
+        attribute :dstSubfolder, String
+      end
+    end
+  end
+end


### PR DESCRIPTION
### :recycle: Current situation & Problem

Fastlane opens and saves the Xcode project to set the bundle identifier and the build number, using a project parser that drops attributes it does not know. It does not know two attributes this project relies on, and reports both while deploying:

```
Xcodeproj doesn't know about the following attributes {"traits" => ["ResearchKit", "Textual", "default"]} for the 'XCRemoteSwiftPackageReference' isa.
Xcodeproj doesn't know about the following attributes {"dstSubfolder" => "Product"} for the 'PBXCopyFilesBuildPhase' isa.
```

Opening and saving the project with that parser, with no other change, removes the `traits` entry and all four `dstSubfolder` entries. The traits select the package products this app builds against, and the destinations are the ones that embed the watch app and the foundation extensions, so a deployment archives from a project that differs from the one in the repository.

No related issue was identified.

### :gear: Release Notes

- Declare the two attributes so the project survives being written by Fastlane unchanged. The deployment lane is otherwise untouched, and the file can be deleted once the parser knows the attributes itself.

### :books: Documentation

`fastlane/xcodeproj_patch.rb` records why it exists and when it can be removed.

### :white_check_mark: Testing

- Opening and saving this project through the parser Fastlane uses was confirmed to remove the `traits` entry and all four `dstSubfolder` entries, and to keep every one of them byte for byte with this change in place
- `reuse lint`, and the Fastfile and the patch parse

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
