### PR TITLE
Scope the User Interface Test Build to Its Own Derived Data

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,6 +74,7 @@ jobs:
             -testPlan 'MyHeartCounts UI Tests' \
             -enableCodeCoverage YES \
             -testProductsPath "$UI_TEST_PRODUCTS_PATH" \
+            -derivedDataPath .derivedData \
             -skipPackagePluginValidation \
             -skipMacroValidation \
             build-for-testing \
@@ -194,19 +195,6 @@ jobs:
           SHARD_RESULT: ${{ needs.mhc_app_ui_test_run.result }}
         run: test "$SHARD_RESULT" = "success"
 
-  # mhc_app_ui_tests:
-  #   name: App UI Tests
-  #   uses: SchmiedmayerLab/.github/.github/workflows/firebase-emulators-exec.yml@v0.5
-  #   permissions:
-  #     contents: read
-  #   with:
-  #     runs_on_labels: '["macOS", "self-hosted"]'
-  #     path: MyHeartCounts-Firebase
-  #     checkout_submodules: true
-  #     artifact: ../MHC-App-UITests.xcresult
-  #     command: npm run prepare && cd .. && fastlane uitest
-  #   secrets:
-  #     GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
   mhc_utils_unit_tests:
     name: Utils Unit Tests (${{ matrix.platform.name }} ${{ matrix.config }})
     uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild.yml@v0.5


### PR DESCRIPTION
### :recycle: Current situation & Problem

The user interface test build writes to the shared derived data directory of the machine it runs on, which every other run on that self-hosted runner writes to as well. When two runs overlap, or when one is cancelled part way through a build, the next run reads a precompiled module that no longer matches the module map it was built from, and the build fails before compiling anything of ours:

```
error: file '.../DerivedData/MyHeartCounts-<hash>/Build/Products/Debug-iphonesimulator/FirebaseFirestoreInternal.framework/Modules/module.modulemap'
has been modified since the module file '.../SwiftExplicitPrecompiledModules/FirebaseFirestoreInternalWrapper-....pcm' was built
** TEST BUILD FAILED **
```

This is the only build in this repository that does not name a derived data path, so it is the only one exposed to it. It happened on the deployment run for the previous change, and re-running the same commit with no edit at all succeeded, which is the signature of a shared cache rather than anything in the project.

The same file also carries a job that was commented out when the user interface tests moved to the sharded build and run they use today. It has been dead since.

No related issue was identified.

### :gear: Release Notes

- Give the user interface test build its own derived data directory, so concurrent and cancelled runs on the same machine can no longer leave a cache behind that fails the next one.
- Remove the superseded user interface test job.

### :books: Documentation

No documentation changes are required.

### :white_check_mark: Testing

- The build the change touches is the one that produced the failure above, and it runs on every pull request, including this one
- `actionlint`

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
